### PR TITLE
fixed Potentially unwanted behaviour in ReplaceIgnoreCase

### DIFF
--- a/src/TinyHelpers/Extensions/StringExtensions.cs
+++ b/src/TinyHelpers/Extensions/StringExtensions.cs
@@ -23,7 +23,7 @@ public static class StringExtensions
     /// <param name="input">The original string</param>
     /// <param name="pattern">The string to be replaced, case insentive.</param>
     /// <param name="replacement">The string to replace all occurrences of <paramref name="pattern"/> </param>
-    /// <returns></returns>
+    /// <returns>A string that is equivalent to the <paramref name="input"/> string except that all instances of <paramref name="pattern"/> are replaced with <paramref name="replacement"/>.</returns>
     public static string ReplaceIgnoreCase(this string input, string pattern, string replacement)
         => Regex.Replace(input, Regex.Escape(pattern), replacement, RegexOptions.IgnoreCase);
 

--- a/src/TinyHelpers/Extensions/StringExtensions.cs
+++ b/src/TinyHelpers/Extensions/StringExtensions.cs
@@ -17,8 +17,15 @@ public static class StringExtensions
     public static bool ContainsIgnoreCase(this string? a, string b)
         => a?.IndexOf(b, StringComparison.OrdinalIgnoreCase) >= 0;
 
+    /// <summary>
+    /// Returns a new string in which all occurrences of a specified string in the current instance are replaced with another specified string, ignoring the letter casing.
+    /// </summary>
+    /// <param name="input">The original string</param>
+    /// <param name="pattern">The string to be replaced, case insentive.</param>
+    /// <param name="replacement">The string to replace all occurrences of <paramref name="pattern"/> </param>
+    /// <returns></returns>
     public static string ReplaceIgnoreCase(this string input, string pattern, string replacement)
-        => Regex.Replace(input, pattern, replacement, RegexOptions.IgnoreCase);
+        => Regex.Replace(input, Regex.Escape(pattern), replacement, RegexOptions.IgnoreCase);
 
     [return: NotNullIfNotNull(nameof(input))]
     public static string? GetValueOrDefault(this string? input)

--- a/tests/TinyHelpers.Tests/Extensions/StringExtensionsTests.cs
+++ b/tests/TinyHelpers.Tests/Extensions/StringExtensionsTests.cs
@@ -46,4 +46,19 @@ public class StringExtensionsTests
         hasValue.Should().BeFalse();
         //Assert.False(hasValue);
     }
+    
+    [Theory]
+    [InlineData(@"\Welcome\world", @"\welcome", @"\hello", @"\hello\world")]
+    [InlineData(@"\Welcome\world", @"\WELCOME", @"\hello", @"\hello\world")]
+    [InlineData(@"\Welcome\world", @".*", @"\hello", @"\Welcome\world")]
+    public void ReplaceIgnoreCase_Should_Replace_Ignoring_Case(string? input, string pattern, string replacement, string expected)
+    {
+        // Arrange
+
+        // Act
+        var newString = input.ReplaceIgnoreCase(pattern, replacement);
+
+        // Assert
+        newString.Should().Be(expected);
+    }
 }

--- a/tests/TinyHelpers.Tests/Extensions/StringExtensionsTests.cs
+++ b/tests/TinyHelpers.Tests/Extensions/StringExtensionsTests.cs
@@ -46,7 +46,7 @@ public class StringExtensionsTests
         hasValue.Should().BeFalse();
         //Assert.False(hasValue);
     }
-    
+
     [Theory]
     [InlineData(@"\Welcome\world", @"\welcome", @"\hello", @"\hello\world")]
     [InlineData(@"\Welcome\world", @"\WELCOME", @"\hello", @"\hello\world")]


### PR DESCRIPTION
resolved #136 , by escaping the `pattern` parameter before performing the regex replacement