### PR TITLE
Enhanced database contexts

### DIFF
--- a/src/TinyHelpers.EntityFrameworkCore/EnhancedDbContexts/SqlServerDbContext.cs
+++ b/src/TinyHelpers.EntityFrameworkCore/EnhancedDbContexts/SqlServerDbContext.cs
@@ -1,0 +1,29 @@
+using System.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.SqlServer;
+
+namespace TinyHelpers.EntityFrameworkCore.EnhancedDbContexts;
+
+public class SqlServerDbContext : DbContext {
+  private string? connectionString;
+
+  public SqlServerDbContext(string? connectionString) {
+    this.connectionString = connectionString;
+    
+    try {
+      Database.EnsureCreated();
+    } catch (Exception ex) {
+      throw new SqlException("An error occurred when connecting to the database.", ex);
+    }
+  }
+  
+  public SqlServerDbContext() : this(null) { }
+  
+  protected virtual void OnConnected(DbContextOptionsBuilder optionsBuilder) { }
+  
+  protected sealed override void OnConfiguring(DbContextOptionsBuilder optionsBuilder) {
+    if (connectionString != null) optionsBuilder.UseSqlServer(connectionString);
+    
+    OnConnected(optionsBuilder);
+  }
+}


### PR DESCRIPTION
I'm a user of these tiny helpers. It came to my mind that I'd like to add my own tiny helper.

I've created a class called `SqlServerDbContext` (inherits from `DbContext`) that represents an enhanced database context for dealing with MS SQL Server database. (Similar classes can be created for other DBMSs.) It doesn't need overriding `OnConfiguring` to specify a custom connection string, for example.

It also automatically sets up the database if it's empty (by calling `Database.EnsureCreated()` in the constructor). It throws `SqlException` with an understandable message when it cannot connect to the database. (`DbContext` would throw `ArgumentException`, which I think isn't a good choice for this case.)

**Note.** All database contexts I use are, in fact, "enhanced" (like the one I'm proposing). I really think it would be a useful addition.