### PR TITLE
 Add Chunk extensions method and Unit Tests

### DIFF
--- a/src/TinyHelpers/Extensions/CollectionExtensions.cs
+++ b/src/TinyHelpers/Extensions/CollectionExtensions.cs
@@ -236,7 +236,7 @@ public static class CollectionExtensions
     /// <param name="chunkSize">The size of each chunk.</param>
     /// <returns>An <see cref="IEnumerable{T}"/> where each element is an array of elements of the specified chunk size.</returns>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="chunkSize"/> is less than 1.</exception>
-    public static IEnumerable<IEnumerable<TSource>> Chunk<TSource>(this IEnumerable<TSource> source, int chunkSize)
+    public static IEnumerable<IEnumerable<TSource>> ChunkBySize<TSource>(this IEnumerable<TSource> source, int chunkSize)
     {
         if (chunkSize < 1)
         {

--- a/src/TinyHelpers/Extensions/CollectionExtensions.cs
+++ b/src/TinyHelpers/Extensions/CollectionExtensions.cs
@@ -227,4 +227,25 @@ public static class CollectionExtensions
     /// <returns>An <see cref="IQueryable{T}"/> that contains elements from the input sequence that satisfy the condition specified by <paramref name="predicate"/>; the unfiltered <paramref name="source"/>, otherwise.</returns>
     public static IQueryable<TSource> WhereIf<TSource>(this IQueryable<TSource> source, bool condition, Expression<Func<TSource, bool>> predicate)
         => condition ? source.Where(predicate) : source;
+
+    /// <summary>
+    /// Splits the source collection into chunks of a specified size.
+    /// </summary>
+    /// <typeparam name="TSource">The type of the elements in the source collection.</typeparam>
+    /// <param name="source">The source collection to split into chunks.</param>
+    /// <param name="chunkSize">The size of each chunk.</param>
+    /// <returns>An <see cref="IEnumerable{T}"/> where each element is an array of elements of the specified chunk size.</returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="chunkSize"/> is less than 1.</exception>
+    public static IEnumerable<IEnumerable<TSource>> Chunk<TSource>(this IEnumerable<TSource> source, int chunkSize)
+    {
+        if (chunkSize < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(chunkSize), "Chunk size must be greater than 0.");
+        }
+
+        return source
+            .Select((value, index) => new { Index = index, Value = value })
+            .GroupBy(x => x.Index / chunkSize)
+            .Select(g => g.Select(x => x.Value));
+    }
 }

--- a/src/TinyHelpers/Extensions/CollectionExtensions.cs
+++ b/src/TinyHelpers/Extensions/CollectionExtensions.cs
@@ -228,6 +228,7 @@ public static class CollectionExtensions
     public static IQueryable<TSource> WhereIf<TSource>(this IQueryable<TSource> source, bool condition, Expression<Func<TSource, bool>> predicate)
         => condition ? source.Where(predicate) : source;
 
+    #if NETSTANDARD2_0
     /// <summary>
     /// Splits the source collection into chunks of a specified size.
     /// </summary>
@@ -236,7 +237,7 @@ public static class CollectionExtensions
     /// <param name="chunkSize">The size of each chunk.</param>
     /// <returns>An <see cref="IEnumerable{T}"/> where each element is an array of elements of the specified chunk size.</returns>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="chunkSize"/> is less than 1.</exception>
-    public static IEnumerable<IEnumerable<TSource>> ChunkBySize<TSource>(this IEnumerable<TSource> source, int chunkSize)
+    public static IEnumerable<IEnumerable<TSource>> Chunk<TSource>(this IEnumerable<TSource> source, int chunkSize)
     {
         if (chunkSize < 1)
         {
@@ -248,4 +249,5 @@ public static class CollectionExtensions
             .GroupBy(x => x.Index / chunkSize)
             .Select(g => g.Select(x => x.Value));
     }
+    #endif
 }

--- a/tests/TinyHelpers.Tests/Extensions/CollectionExtensionsTests.cs
+++ b/tests/TinyHelpers.Tests/Extensions/CollectionExtensionsTests.cs
@@ -12,7 +12,7 @@ public class CollectionExtensionsTests
         int chunkSize = 3;
 
         // Act
-        var result = source.ChunkBySize(chunkSize).ToList();
+        var result = source.Chunk(chunkSize).ToList();
 
         // Assert
         Assert.Equal(2, result.Count);
@@ -28,7 +28,7 @@ public class CollectionExtensionsTests
         int chunkSize = 3;
 
         // Act
-        var result = source.ChunkBySize(chunkSize).ToList();
+        var result = source.Chunk(chunkSize).ToList();
 
         // Assert
         Assert.Equal(3, result.Count);

--- a/tests/TinyHelpers.Tests/Extensions/CollectionExtensionsTests.cs
+++ b/tests/TinyHelpers.Tests/Extensions/CollectionExtensionsTests.cs
@@ -1,0 +1,78 @@
+﻿using TinyHelpers.Extensions;
+
+namespace TinyHelpers.Tests.Extensions;
+
+public class CollectionExtensionsTests
+{
+    [Fact]
+    public void Chunk_ExactMultipleChunkSize_ReturnsEqualChunks()
+    {
+        // Arrange
+        var source = Enumerable.Range(1, 6);
+        int chunkSize = 3;
+
+        // Act
+        var result = source.ChunkBySize(chunkSize).ToList();
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Equal(new[] { 1, 2, 3 }, result[0].ToArray());
+        Assert.Equal(new[] { 4, 5, 6 }, result[1].ToArray());
+    }
+
+    [Fact]
+    public void Chunk_ChunkSizeNotDivisible_ReturnsLastChunkSmaller()
+    {
+        // Arrange
+        var source = Enumerable.Range(1, 7);
+        int chunkSize = 3;
+
+        // Act
+        var result = source.ChunkBySize(chunkSize).ToList();
+
+        // Assert
+        Assert.Equal(3, result.Count);
+        Assert.Equal(new[] { 1, 2, 3 }, result[0].ToArray());
+        Assert.Equal(new[] { 4, 5, 6 }, result[1].ToArray());
+        Assert.Equal(new[] { 7 }, result[2].ToArray());
+    }
+
+    [Fact]
+    public void GetLongCount_PredicateAlwaysTrue_ReturnsTotalCount()
+    {
+        // Arrange
+        var source = Enumerable.Range(1, 10);
+
+        // Act
+        long result = source.GetLongCount(x => true);
+
+        // Assert
+        Assert.Equal(10, result);
+    }
+
+    [Fact]
+    public void GetLongCount_PredicateAlwaysFalse_ReturnsZero()
+    {
+        // Arrange
+        var source = Enumerable.Range(1, 10);
+
+        // Act
+        long result = source.GetLongCount(x => x > 10);
+
+        // Assert
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void Remove_MatchingElements_RemovesCorrectElements()
+    {
+        // Arrange
+        var collection = new List<int> { 1, 2, 3, 4, 5 };
+
+        // Act
+        collection.Remove(x => x % 2 == 0);
+
+        // Assert
+        Assert.Equal(new[] { 1, 3, 5 }, collection);
+    }
+}


### PR DESCRIPTION
- Add `ChunkBySize` extensions method: splits the source collection into chunks of a specified size.
- Add CollectionExtensionsTests class for Collection UnitTests