### PR TITLE
Reduce memory allocation in AllowedExtensionsAttribute and ContentTypeAttribute

### DIFF
--- a/src/TinyHelpers.AspNetCore/DataAnnotations/AllowedExtensionsAttribute.cs
+++ b/src/TinyHelpers.AspNetCore/DataAnnotations/AllowedExtensionsAttribute.cs
@@ -7,14 +7,14 @@ namespace TinyHelpers.AspNetCore.DataAnnotations;
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
 public class AllowedExtensionsAttribute(params string[] extensions) : ValidationAttribute("Only files with the following extensions are supported: {0}")
 {
-    private readonly IEnumerable<string> extensions = extensions.Select(e => e.ToLowerInvariant().Replace("*.", string.Empty));
+    private readonly IEnumerable<string> extensions = extensions.Select(e => e.Replace("*.", string.Empty));
 
     protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
     {
         if (value is IFormFile file)
         {
-            var extension = Path.GetExtension(file.FileName).ToLower()[1..];
-            if (!extensions.Contains(extension))
+            var extension = Path.GetExtension(file.FileName)[1..];
+            if (!extensions.Contains(extension, StringComparer.OrdinalIgnoreCase))
             {
                 return new ValidationResult(FormatErrorMessage(validationContext.DisplayName));
             }

--- a/src/TinyHelpers.AspNetCore/DataAnnotations/ContentTypeAttribute.cs
+++ b/src/TinyHelpers.AspNetCore/DataAnnotations/ContentTypeAttribute.cs
@@ -26,7 +26,7 @@ public class ContentTypeAttribute : ValidationAttribute
     public ContentTypeAttribute(params string[] validContentTypes)
         : base(DefaultErrorMessage)
     {
-        this.validContentTypes = validContentTypes.Select(s => s.ToLowerInvariant());
+        this.validContentTypes = validContentTypes;
     }
 
     public ContentTypeAttribute(FileType fileType)
@@ -43,7 +43,7 @@ public class ContentTypeAttribute : ValidationAttribute
 
     protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
     {
-        if (value is IFormFile formFile && !validContentTypes.Contains(formFile.ContentType))
+        if (value is IFormFile formFile && !validContentTypes.Contains(formFile.ContentType, StringComparer.OrdinalIgnoreCase))
         {
             return new ValidationResult(FormatErrorMessage(validationContext.DisplayName));
         }


### PR DESCRIPTION
Reduce memory allocation in AllowedExtensionsAttribute and ContentTypeAttribute by performing a case-insensitive comparison.