### PR TITLE
Use TryAdd for traceId in ProblemDetails.Extensions

### DIFF
--- a/src/TinyHelpers.AspNetCore/Extensions/ServiceCollectionExtensions.cs
+++ b/src/TinyHelpers.AspNetCore/Extensions/ServiceCollectionExtensions.cs
@@ -73,7 +73,7 @@ public static class ServiceCollectionExtensions
                 context.ProblemDetails.Type ??= $"https://httpstatuses.io/{statusCode}";
                 context.ProblemDetails.Title ??= ReasonPhrases.GetReasonPhrase(statusCode);
                 context.ProblemDetails.Instance ??= context.HttpContext.Request.Path;
-                context.ProblemDetails.Extensions["traceId"] = Activity.Current?.Id ?? context.HttpContext.TraceIdentifier;
+                context.ProblemDetails.Extensions.TryAdd("traceId", Activity.Current?.Id ?? context.HttpContext.TraceIdentifier);
             };
         });
 


### PR DESCRIPTION
Modified the code to use the TryAdd method for adding the "traceId" to the ProblemDetails.Extensions dictionary. This change prevents potential overwrites of the "traceId" key, enhancing the robustness of the code by ensuring the key is only added if it does not already exist.