### PR TITLE
Ensure ProblemDetails service is registered

### DIFF
--- a/src/TinyHelpers.AspNetCore/Extensions/ServiceCollectionExtensions.cs
+++ b/src/TinyHelpers.AspNetCore/Extensions/ServiceCollectionExtensions.cs
@@ -84,6 +84,9 @@ public static class ServiceCollectionExtensions
 #if NET8_0_OR_GREATER
     public static IServiceCollection AddDefaultExceptionHandler(this IServiceCollection services)
     {
+        // Ensures that the ProblemDetails service is registered.
+        services.AddProblemDetails();
+
         services.AddExceptionHandler<DefaultExceptionHandler>();
         return services;
     }


### PR DESCRIPTION
Modified the AddDefaultExceptionHandler method in the ServiceCollectionExtensions class to include the
registration of the ProblemDetails service by adding services.AddProblemDetails().