### PR TITLE
Update package versions in multiple project files

### DIFF
--- a/samples/TinyHelpers.AspNetCore.Sample/TinyHelpers.AspNetCore.Sample.csproj
+++ b/samples/TinyHelpers.AspNetCore.Sample/TinyHelpers.AspNetCore.Sample.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.8" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.8.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.8.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/TinyHelpers.Dapper.Sample/TinyHelpers.Dapper.Sample.csproj
+++ b/samples/TinyHelpers.Dapper.Sample/TinyHelpers.Dapper.Sample.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.12.0" />
+    <PackageReference Include="Azure.Identity" Version="1.12.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
   </ItemGroup>
 

--- a/src/TinyHelpers.AspNetCore/TinyHelpers.AspNetCore.csproj
+++ b/src/TinyHelpers.AspNetCore/TinyHelpers.AspNetCore.csproj
@@ -25,7 +25,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.8.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.8.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/TinyHelpers.Tests/TinyHelpers.Tests.csproj
+++ b/tests/TinyHelpers.Tests/TinyHelpers.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="xunit" Version="2.9.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Updated the following package versions:
- `Swashbuckle.AspNetCore` in `TinyHelpers.AspNetCore.Sample.csproj` from `6.8.0` to `6.8.1`
- `Azure.Identity` in `TinyHelpers.Dapper.Sample.csproj` from `1.12.0` to `1.12.1`
- `Swashbuckle.AspNetCore.SwaggerGen` in `TinyHelpers.AspNetCore.csproj` from `6.8.0` to `6.8.1`
- `xunit` in `TinyHelpers.Tests.csproj` from `2.9.1` to `2.9.2`