### PR TITLE
Update package versions in various project files

### DIFF
--- a/samples/TinyHelpers.AspNetCore.Sample/TinyHelpers.AspNetCore.Sample.csproj
+++ b/samples/TinyHelpers.AspNetCore.Sample/TinyHelpers.AspNetCore.Sample.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.10" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.8.1" />
   </ItemGroup>
 

--- a/samples/TinyHelpers.EntityFrameworkCore.Sample/TinyHelpers.EntityFrameworkCore.Sample.csproj
+++ b/samples/TinyHelpers.EntityFrameworkCore.Sample/TinyHelpers.EntityFrameworkCore.Sample.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.10" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/TinyHelpers.Dapper/TinyHelpers.Dapper.csproj
+++ b/src/TinyHelpers.Dapper/TinyHelpers.Dapper.csproj
@@ -22,7 +22,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Dapper" Version="2.1.35" />		
-		<PackageReference Include="TinyHelpers" Version="3.1.16" />
+		<PackageReference Include="TinyHelpers" Version="3.1.18" />
 	</ItemGroup>
 
     <ItemGroup>

--- a/src/TinyHelpers.EntityFrameworkCore/TinyHelpers.EntityFrameworkCore.csproj
+++ b/src/TinyHelpers.EntityFrameworkCore/TinyHelpers.EntityFrameworkCore.csproj
@@ -21,11 +21,11 @@
 	</PropertyGroup>
 
 	<ItemGroup>		
-		<PackageReference Include="TinyHelpers" Version="3.1.16" />
+		<PackageReference Include="TinyHelpers" Version="3.1.18" />
 	</ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.33" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.35" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
@@ -33,7 +33,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.8" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.10" />
     </ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Updated the following package versions:
- `Microsoft.AspNetCore.OpenApi` in `TinyHelpers.AspNetCore.Sample.csproj` from `8.0.8` to `8.0.10`.
- `Microsoft.EntityFrameworkCore.SqlServer` in `TinyHelpers.EntityFrameworkCore.Sample.csproj` from `8.0.8` to `8.0.10`.
- `TinyHelpers` in `TinyHelpers.Dapper.csproj` from `3.1.16` to `3.1.18`.
- `TinyHelpers` in `TinyHelpers.EntityFrameworkCore.csproj` from `3.1.16` to `3.1.18`.
- `Microsoft.EntityFrameworkCore.Relational` in `TinyHelpers.EntityFrameworkCore.csproj` for `net6.0` from `6.0.33` to `6.0.35`.
- `Microsoft.EntityFrameworkCore.Relational` in `TinyHelpers.EntityFrameworkCore.csproj` for `net8.0` from `8.0.8` to `8.0.10`.