### PR TITLE
Update Swashbuckle, add JSON converter, mark obsolete

### DIFF
--- a/samples/TinyHelpers.AspNetCore.Sample/TinyHelpers.AspNetCore.Sample.csproj
+++ b/samples/TinyHelpers.AspNetCore.Sample/TinyHelpers.AspNetCore.Sample.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/TinyHelpers.Sample/Program.cs
+++ b/samples/TinyHelpers.Sample/Program.cs
@@ -23,6 +23,7 @@ Console.WriteLine(distinctPeople);
 var jsonSerializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web);
 jsonSerializerOptions.Converters.Add(new UtcDateTimeConverter());
 jsonSerializerOptions.Converters.Add(new StringTrimmingConverter());
+jsonSerializerOptions.Converters.Add(new StringEnumMemberConverter());
 
 var person = new Person("Donald ", "Duck ", " Duckburg  ") { DateOfBirth = DateTime.Now };
 var json = JsonSerializer.Serialize(person, jsonSerializerOptions);

--- a/src/TinyHelpers/Json/Serialization/StringEnumMemberConverter.cs
+++ b/src/TinyHelpers/Json/Serialization/StringEnumMemberConverter.cs
@@ -7,10 +7,11 @@ using System.Text.Json.Serialization;
 namespace TinyHelpers.Json.Serialization;
 
 /// <summary>
-/// Converts an <see cref="Enum"/> value to or from JSON, keeping only the date part.
+/// Converts an <see cref="Enum"/> value to or from JSON.
 /// </summary>
 /// <param name="namingPolicy">The naming policy used to resolve how property names and dictionary keys are formatted.</param>
 /// <param name="allowIntegerValues">Specifies whether integer values are allowed for input.</param>
+[Obsolete("Use System.Text.Json.Serialization.JsonStringEnumMemberConverter and System.Text.Json.Serialization.JsonStringEnumMemberName instead.")]
 public class StringEnumMemberConverter(JsonNamingPolicy? namingPolicy, bool allowIntegerValues) : JsonConverterFactory
 {
     /// <summary>
@@ -118,7 +119,7 @@ public class StringEnumMemberConverter(JsonNamingPolicy? namingPolicy, bool allo
                 {
                     var calculatedValue = 0UL;
 
-                    var flagValues = enumString.Split(new string[] { ", " }, StringSplitOptions.None);
+                    var flagValues = enumString.Split([", "], StringSplitOptions.None);
                     foreach (var flagValue in flagValues)
                     {
                         // Case sensitive search attempted first.


### PR DESCRIPTION
Updated Swashbuckle.AspNetCore to 7.1.0 in csproj file. Added StringEnumMemberConverter to JSON options in Program.cs. Corrected summary comment for StringEnumMemberConverter class. Marked StringEnumMemberConverter as obsolete, suggesting alternatives. Updated Split method call to use new array syntax for delimiter.