### PR TITLE
Refactor condition checks and update SwaggerGen version

### DIFF
--- a/src/TinyHelpers.AspNetCore/Swagger/AcceptLanguageHeaderOperationFilter.cs
+++ b/src/TinyHelpers.AspNetCore/Swagger/AcceptLanguageHeaderOperationFilter.cs
@@ -16,7 +16,7 @@ internal class AcceptLanguageHeaderOperationFilter(IOptions<RequestLocalizationO
 
     public void Apply(OpenApiOperation operation, OperationFilterContext context)
     {
-        if (supportedLanguages?.Any() ?? false)
+        if (supportedLanguages?.Count > 0)
         {
             operation.Parameters ??= [];
 

--- a/src/TinyHelpers.AspNetCore/Swagger/OpenApiParametersOperationFilter.cs
+++ b/src/TinyHelpers.AspNetCore/Swagger/OpenApiParametersOperationFilter.cs
@@ -8,7 +8,7 @@ internal class OpenApiParametersOperationFilter(OpenApiOperationOptions openApiP
 {
     public void Apply(OpenApiOperation operation, OperationFilterContext context)
     {
-        if (openApiParameters?.Parameters.Any() ?? false)
+        if (openApiParameters?.Parameters.Count > 0)
         {
             operation.Parameters ??= [];
 

--- a/src/TinyHelpers.AspNetCore/TinyHelpers.AspNetCore.csproj
+++ b/src/TinyHelpers.AspNetCore/TinyHelpers.AspNetCore.csproj
@@ -25,7 +25,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="7.0.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="7.1.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Refactored condition checks for collections in AcceptLanguageHeaderOperationFilter and OpenApiParametersOperationFilter classes to use Count property instead of Any() method. Updated Swashbuckle.AspNetCore.SwaggerGen package version in TinyHelpers.AspNetCore.csproj from 7.0.0 to 7.1.0.