### PR TITLE
Update packages, frameworks, and improve Split method

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.143"  PrivateAssets="All" />
+        <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.146"  PrivateAssets="All" />
     </ItemGroup>
 
 </Project>

--- a/src/TinyHelpers.Dapper/TinyHelpers.Dapper.csproj
+++ b/src/TinyHelpers.Dapper/TinyHelpers.Dapper.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
@@ -22,7 +22,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Dapper" Version="2.1.35" />		
-		<PackageReference Include="TinyHelpers" Version="3.1.18" />
+		<PackageReference Include="TinyHelpers" Version="3.2.3" />
 	</ItemGroup>
 
     <ItemGroup>

--- a/src/TinyHelpers.Dapper/TypeHandlers/StringArrayTypeHandler.cs
+++ b/src/TinyHelpers.Dapper/TypeHandlers/StringArrayTypeHandler.cs
@@ -8,7 +8,7 @@ public class StringArrayTypeHandler(string separator = ";") : SqlMapper.TypeHand
     public override string[] Parse(object value)
     {
         var content = value.ToString()!;
-        return content.Split(new string[] { separator }, StringSplitOptions.RemoveEmptyEntries);
+        return content.Split([separator], StringSplitOptions.RemoveEmptyEntries);
     }
 
     public override void SetValue(IDbDataParameter parameter, string[]? value)

--- a/src/TinyHelpers.Dapper/TypeHandlers/StringEnumerableTypeHandler.cs
+++ b/src/TinyHelpers.Dapper/TypeHandlers/StringEnumerableTypeHandler.cs
@@ -8,7 +8,7 @@ public class StringEnumerableTypeHandler(string separator = ";") : SqlMapper.Typ
     public override IEnumerable<string> Parse(object value)
     {
         var content = value.ToString()!;
-        return content.Split(new string[] { separator }, StringSplitOptions.RemoveEmptyEntries);
+        return content.Split([separator], StringSplitOptions.RemoveEmptyEntries);
     }
 
     public override void SetValue(IDbDataParameter parameter, IEnumerable<string>? value)

--- a/src/TinyHelpers.Dapper/version.json
+++ b/src/TinyHelpers.Dapper/version.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-	"version": "3.0",
+	"version": "3.2",
 	"publicReleaseRefSpec": [
 		"^refs/heads/master$" // we release out of master
 	],


### PR DESCRIPTION
Updated Nerdbank.GitVersioning to 3.6.146 in Directory.Build.props. Modified target frameworks in TinyHelpers.Dapper.csproj: removed net6.0 and net7.0, added net9.0. Updated TinyHelpers package reference to 3.2.3.
Improved Split method in StringArrayTypeHandler.cs and StringEnumerableTypeHandler.cs with new array syntax. Updated version in version.json to 3.2.

Closes #218