### PR TITLE
Update .NET version in publish_dapper.yml to 9.x

### DIFF
--- a/.github/workflows/publish_dapper.yml
+++ b/.github/workflows/publish_dapper.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  NET_VERSION: '8.x'
+  NET_VERSION: '9.x'
   PROJECT_NAME: src/TinyHelpers.Dapper 
   PROJECT_FILE: TinyHelpers.Dapper.csproj
   TAG_NAME: dapper


### PR DESCRIPTION
The `NET_VERSION` environment variable in the `publish_dapper.yml` file has been updated from '8.x' to '9.x'. This change upgrades the .NET version used in the workflow configuration for the project `TinyHelpers.Dapper`.