### PR TITLE
Add OpenAPI parameters to all operations

### DIFF
--- a/samples/TinyHelpers.AspNetCore.Sample/Program.cs
+++ b/samples/TinyHelpers.AspNetCore.Sample/Program.cs
@@ -1,3 +1,4 @@
+using Microsoft.OpenApi.Models;
 using TinyHelpers.AspNetCore.Extensions;
 using TinyHelpers.AspNetCore.OpenApi;
 
@@ -6,10 +7,46 @@ var builder = WebApplication.CreateBuilder(args);
 // Add services to the container.
 builder.Services.AddRequestLocalization("it", "en", "de");
 
+// Add OpenAPI parameters that are required for all operations.
+builder.Services.AddOpenApiOperationParameters(options =>
+{
+    options.Parameters.Add(new()
+    {
+        Name = "x-tenant",
+        In = ParameterLocation.Header,
+        Required = true,
+        Schema = OpenApiSchemaHelper.CreateStringSchema()
+    });
+
+    options.Parameters.Add(new()
+    {
+        Name = "x-environment",
+        In = ParameterLocation.Header,
+        Schema = OpenApiSchemaHelper.CreateSchema<Environment>(Environment.Production)
+    });
+
+    options.Parameters.Add(new()
+    {
+        Name = "code",
+        In = ParameterLocation.Query,
+        Schema = OpenApiSchemaHelper.CreateSchema<Guid>("string", "uuid")
+    });
+
+    options.Parameters.Add(new()
+    {
+        Name = "version",
+        In = ParameterLocation.Query,
+        Schema = OpenApiSchemaHelper.CreateSchema<int>("integer", "int32", 1)
+    });
+});
+
 builder.Services.AddOpenApi(options =>
 {
     options.AddAcceptLanguageHeader();
     options.AddDefaultResponse();
+
+    // Enable OpenAPI integration for custom parameters.
+    options.AddOperationParameters();
 });
 
 // Add default problem details and exception handler.
@@ -50,3 +87,10 @@ app.MapPost("/api/exception", () =>
 .ProducesProblem(StatusCodes.Status400BadRequest);
 
 app.Run();
+
+public enum Environment
+{
+    Development,
+    Staging,
+    Production
+}

--- a/samples/TinyHelpers.AspNetCore.Sample/TinyHelpers.AspNetCore.Sample.csproj
+++ b/samples/TinyHelpers.AspNetCore.Sample/TinyHelpers.AspNetCore.Sample.csproj
@@ -12,7 +12,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\TinyHelpers.AspNetCore.Swashbuckle\TinyHelpers.AspNetCore.Swashbuckle.csproj" />
     <ProjectReference Include="..\..\src\TinyHelpers.AspNetCore\TinyHelpers.AspNetCore.csproj" />
   </ItemGroup>
 

--- a/samples/TinyHelpers.AspNetCore8.Sample/Program.cs
+++ b/samples/TinyHelpers.AspNetCore8.Sample/Program.cs
@@ -9,7 +9,7 @@ builder.Services.AddRequestLocalization("it", "en", "de");
 
 builder.Services.AddEndpointsApiExplorer();
 
-// Add parameters that are required for all operations.
+// Add Swagger parameters that are required for all operations.
 builder.Services.AddSwaggerOperationParameters(options =>
 {
     options.Parameters.Add(new()

--- a/src/TinyHelpers.AspNetCore/OpenApi/OpenApiExtensions.cs
+++ b/src/TinyHelpers.AspNetCore/OpenApi/OpenApiExtensions.cs
@@ -1,6 +1,7 @@
 ﻿#if NET9_0_OR_GREATER
 
 using Microsoft.AspNetCore.OpenApi;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace TinyHelpers.AspNetCore.OpenApi;
 
@@ -11,6 +12,22 @@ public static class OpenApiExtensions
 
     public static void AddDefaultResponse(this OpenApiOptions options)
         => options.AddOperationTransformer<DefaultResponseOperationTransformer>();
+
+    public static IServiceCollection AddOpenApiOperationParameters(this IServiceCollection services, Action<OpenApiOperationOptions> setupAction)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(setupAction);
+
+        var parameters = new OpenApiOperationOptions();
+        setupAction.Invoke(parameters);
+
+        services.AddTransient(_ => parameters);
+
+        return services;
+    }
+
+    public static void AddOperationParameters(this OpenApiOptions options)
+        => options.AddOperationTransformer<OpenApiParametersOperationFilter>();
 }
 
 #endif

--- a/src/TinyHelpers.AspNetCore/OpenApi/OpenApiParametersOperationTransformer.cs
+++ b/src/TinyHelpers.AspNetCore/OpenApi/OpenApiParametersOperationTransformer.cs
@@ -1,12 +1,14 @@
-﻿using Microsoft.OpenApi.Any;
+﻿#if NET9_0_OR_GREATER
+
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
-using Swashbuckle.AspNetCore.SwaggerGen;
 
-namespace TinyHelpers.AspNetCore.Swagger;
+namespace TinyHelpers.AspNetCore.OpenApi;
 
-internal class OpenApiParametersOperationFilter(OpenApiOperationOptions options) : IOperationFilter
+internal class OpenApiParametersOperationFilter(OpenApiOperationOptions options) : IOpenApiOperationTransformer
 {
-    public void Apply(OpenApiOperation operation, OperationFilterContext context)
+    public Task TransformAsync(OpenApiOperation operation, OpenApiOperationTransformerContext context, CancellationToken cancellationToken)
     {
         if (options?.Parameters.Count > 0)
         {
@@ -17,6 +19,8 @@ internal class OpenApiParametersOperationFilter(OpenApiOperationOptions options)
                 operation.Parameters.Add(parameter);
             }
         }
+
+        return Task.CompletedTask;
     }
 }
 
@@ -89,3 +93,5 @@ public static class OpenApiSchemaHelper
         return schema;
     }
 }
+
+#endif

--- a/src/TinyHelpers.AspNetCore/README.md
+++ b/src/TinyHelpers.AspNetCore/README.md
@@ -24,16 +24,15 @@ dotnet add package TinyHelpers.AspNetCore
 
 The library provides some useful extension methods for ASP.NET Core applications:
 
-- `AddDefaultProblemDetails()`: calls the default [ProblemDetails](https://learn.microsoft.com/dotnet/api/microsoft.extensions.dependencyinjection.problemdetailsservicecollectionextensions) extension method defining the [CustomizeProblemDetails](https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.http.problemdetailsoptions.customizeproblemdetails) property to ensure that all the typical properties (_Type_, _Title_, _Instance_, _TraceId_) are correctly set.
+- `AddDefaultProblemDetails`: calls the default [ProblemDetails](https://learn.microsoft.com/dotnet/api/microsoft.extensions.dependencyinjection.problemdetailsservicecollectionextensions) extension method defining the [CustomizeProblemDetails](https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.http.problemdetailsoptions.customizeproblemdetails) property to ensure that all the typical properties (_Type_, _Title_, _Instance_, _TraceId_) are correctly set.
 
-- `AddDefaultExceptionHandler()`: adds a default implementation for the [IExceptionHandler](https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.diagnostics.iexceptionhandler) interface that returns the following response on exceptions:
+- `AddDefaultExceptionHandler`: adds a default implementation for the [IExceptionHandler](https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.diagnostics.iexceptionhandler) interface that returns the following response on exceptions:
 
 ```csharp
 app.MapPost("/api/exception", () =>
 {
     throw new Exception("This is an exception", innerException: new HttpRequestException("This is an inner exception"));
-})
-.WithOpenApi();
+});
 ```
 ```json
 {
@@ -55,6 +54,15 @@ The _StackTrace_ property is included in the response only if the application is
 - `AddRequestLocalization(cultures)`: an overload of the standard [AddRequestLocalization](https://learn.microsoft.com/dotnet/api/microsoft.extensions.dependencyinjection.requestlocalizationservicecollectionextensions) extension method that just requires the list of supported cultures and automatically registers the corresponding [RequestLocalizationOptions](https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.builder.requestlocalizationoptions) (Note: The first culture in the list is used as the default culture).
 
 - `ConfigureAndGet<TOptions>(  )`: it allows to register a configuration instance on type _TOptions_ and returns the instance itself. It is useful when you need to configure the options and gets the reference to that instance in the same method, typically at application startup.
+
+- `AddAcceptLanguageHeader()`: adds the _Accept-Language_ header to OpenAPI definition:
+
+```csharp
+builder.Services.AddOpenApi(options =>
+{
+    options.AddAcceptLanguageHeader();
+});
+```
 
 **Contribute**
 


### PR DESCRIPTION
This pull request includes several changes to enhance OpenAPI integration and improve code readability. The most important changes include adding OpenAPI parameters for all operations, introducing a new enum for environments, and updating method names for consistency.

Enhancements to OpenAPI integration:

* [`samples/TinyHelpers.AspNetCore.Sample/Program.cs`](diffhunk://#diff-df7fae3008b0994995749092b1d506f28cf6a598dc0f01a497007b17e978e3d1R10-R49): Added OpenAPI parameters required for all operations, including headers and query parameters.
* [`src/TinyHelpers.AspNetCore/OpenApi/OpenApiExtensions.cs`](diffhunk://#diff-3fb0a3c16ab2e79f5927e9d359c8ce1eee977ddf5094cf176e408f9fdffb3a3fR15-R30): Added methods `AddOpenApiOperationParameters` and `AddOperationParameters` to configure and apply OpenAPI parameters.

Code readability improvements:

* [`src/TinyHelpers.AspNetCore.Swashbuckle/OpenApiParametersOperationFilter.cs`](diffhunk://#diff-46009c766622b95aa8bf1477bb659fbb8dfda56f8e1d92d597791edf48b6dfbeL7-R15): Renamed parameter `openApiParameters` to `options` for consistency.
* [`samples/TinyHelpers.AspNetCore.Sample/Program.cs`](diffhunk://#diff-df7fae3008b0994995749092b1d506f28cf6a598dc0f01a497007b17e978e3d1R90-R96): Introduced `Environment` enum to represent different environments.

Documentation updates:

* [`src/TinyHelpers.AspNetCore/README.md`](diffhunk://#diff-5c2f9a04e5414b87d9888d0d77f3a7587e4193dc13ca22c383ad178fe6f2ce92L27-R35): Updated method names in documentation for consistency and added a section on `AddAcceptLanguageHeader`. [[1]](diffhunk://#diff-5c2f9a04e5414b87d9888d0d77f3a7587e4193dc13ca22c383ad178fe6f2ce92L27-R35) [[2]](diffhunk://#diff-5c2f9a04e5414b87d9888d0d77f3a7587e4193dc13ca22c383ad178fe6f2ce92R58-R66)