### PR TITLE
Add TimeSpan TypeHandler for Dapper

### DIFF
--- a/src/TinyHelpers.Dapper/TypeHandlers/TimeSpanTypeHandler.cs
+++ b/src/TinyHelpers.Dapper/TypeHandlers/TimeSpanTypeHandler.cs
@@ -1,0 +1,31 @@
+using System.Data;
+using Dapper;
+
+namespace TinyHelpers.Dapper.TypeHandlers;
+
+#if NET6_0_OR_GREATER
+public class TimeSpanTypeHandler : SqlMapper.TypeHandler<TimeSpan>
+{
+    public override TimeSpan Parse(object value)
+    {
+        return value switch
+        {
+            null => TimeSpan.Zero,
+            string stringValue => TimeSpan.Parse(stringValue),
+            long longValue => TimeSpan.FromTicks(longValue),
+            int intValue => TimeSpan.FromSeconds(intValue),
+            double doubleValue => TimeSpan.FromSeconds(doubleValue),
+            _ => throw new ArgumentException($"Unable to convert {value.GetType()} to {nameof(TimeSpan)}"),
+        };
+    }
+
+    public override void SetValue(IDbDataParameter parameter, TimeSpan value)
+    {
+        parameter.Value = value.Ticks;
+        parameter.DbType = DbType.Int64;
+    }
+
+    public static void Configure()
+        => SqlMapper.AddTypeHandler(new TimeSpanTypeHandler());
+}
+#endif


### PR DESCRIPTION
# Add TimeSpan TypeHandler for Dapper

## 🎯 Purpose
Adds a custom TypeHandler for TimeSpan to improve data type mapping between database and .NET objects when using Dapper.

Closes #108

## 🔍 Changes
- Added `TimeSpanTypeHandler` class that handles TimeSpan serialization/deserialization
- Implements flexible parsing from various data types (string, long, int, double)
- Stores TimeSpan values as ticks (BIGINT) in the database
- Added NET6_0_OR_GREATER conditional compilation to ensure compatibility
- Provides a static Configure() method for easy registration