### PR TITLE
N1K0232/issue236

### DIFF
--- a/src/TinyHelpers.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
+++ b/src/TinyHelpers.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
@@ -32,4 +32,13 @@ public static class ModelBuilderExtensions
             }
         }
     }
+
+    public static IEnumerable<Type> GetEntityTypes(this ModelBuilder modelBuilder, Type baseType)
+    {
+        var entityTypes = modelBuilder.Model.GetEntityTypes()
+            .Where(t => baseType.IsAssignableFrom(t.ClrType))
+            .ToList();
+
+        return entityTypes.Select(t => t.ClrType);
+    }
 }


### PR DESCRIPTION
Solved the issue #236

Now it's possible to get the list of entity types from the ModelBuilder by passing a default type as argument.
I was thinking that I can also change the signature by using a generic type, so that the signature of the method would be

public static IEnumerable<EntityTypes> GetEntityTypes<T>(this ModelBuilder builder) where T : class
{
}

Closes #236 