### PR TITLE
Update TinyHelpers package to version 3.2.16

### DIFF
--- a/src/TinyHelpers.Dapper/TinyHelpers.Dapper.csproj
+++ b/src/TinyHelpers.Dapper/TinyHelpers.Dapper.csproj
@@ -22,7 +22,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Dapper" Version="2.1.35" />		
-		<PackageReference Include="TinyHelpers" Version="3.2.3" />
+		<PackageReference Include="TinyHelpers" Version="3.2.16" />
 	</ItemGroup>
 
     <ItemGroup>

--- a/src/TinyHelpers.EntityFrameworkCore/TinyHelpers.EntityFrameworkCore.csproj
+++ b/src/TinyHelpers.EntityFrameworkCore/TinyHelpers.EntityFrameworkCore.csproj
@@ -21,7 +21,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>		
-		<PackageReference Include="TinyHelpers" Version="3.2.3" />
+		<PackageReference Include="TinyHelpers" Version="3.2.16" />
 	</ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">


### PR DESCRIPTION
This pull request includes updates to the `TinyHelpers` package version in two project files.

* [`src/TinyHelpers.Dapper/TinyHelpers.Dapper.csproj`](diffhunk://#diff-a5e600d5a0bec6a3a1868d6104e2a782b57b725a53fea5d52c682fb58a3b0987L25-R25): Updated `TinyHelpers` package version from 3.2.3 to 3.2.16.
* [`src/TinyHelpers.EntityFrameworkCore/TinyHelpers.EntityFrameworkCore.csproj`](diffhunk://#diff-6cb818b6e59a513f8a0ede12f92eb2cdb120526af82a5e520850eba0e74e976dL24-R24): Updated `TinyHelpers` package version from 3.2.3 to 3.2.16.