### PR TITLE
Refactor and enhance type safety in extensions

### DIFF
--- a/src/TinyHelpers.AspNetCore.Swashbuckle/SwaggerExtensions.cs
+++ b/src/TinyHelpers.AspNetCore.Swashbuckle/SwaggerExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using System.ComponentModel;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Any;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using TinyHelpers.AspNetCore.Swagger.Filters;
@@ -17,6 +18,7 @@ public static class SwaggerExtensions
     }
 
     [Obsolete("Use AddDefaultProblemDetailsResponse instead.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static void AddDefaultResponse(this SwaggerGenOptions options)
         => options.AddDefaultProblemDetailsResponse();
 

--- a/src/TinyHelpers.AspNetCore/OpenApi/OpenApiExtensions.cs
+++ b/src/TinyHelpers.AspNetCore/OpenApi/OpenApiExtensions.cs
@@ -1,5 +1,6 @@
 ﻿#if NET9_0_OR_GREATER
 
+using System.ComponentModel;
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.Extensions.DependencyInjection;
 using TinyHelpers.AspNetCore.OpenApi.Transformers;
@@ -20,6 +21,7 @@ public static class OpenApiExtensions
     }
 
     [Obsolete("Use AddDefaultProblemDetailsResponse instead.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static OpenApiOptions AddDefaultResponse(this OpenApiOptions options)
         => options.AddDefaultProblemDetailsResponse();
 

--- a/src/TinyHelpers/Extensions/CollectionExtensions.cs
+++ b/src/TinyHelpers/Extensions/CollectionExtensions.cs
@@ -17,8 +17,8 @@ public static class CollectionExtensions
     /// <typeparam name="TKey">The type of key to distinguish elements by.</typeparam>
     /// <param name="source">The sequence to remove duplicate elements from.</param>
     /// <param name="keySelector">A function to extract the key for each element.</param>
-    /// <param name="comparer">An <see cref="IEqualityComparer{T}"/> to compare keys.</param>
-    /// <returns>An <see cref="IEnumerable{T}"/> that contains distinct elements from the source sequence.</returns>
+    /// <param name="comparer">An <see cref="IEqualityComparer{TKey}"/> to compare keys.</param>
+    /// <returns>An <see cref="IEnumerable{TSource}"/> that contains distinct elements from the source sequence.</returns>
     public static IEnumerable<TSource> DistinctBy<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer = null)
         => source.GroupBy(keySelector, comparer).Select(x => x.First());
 
@@ -28,7 +28,7 @@ public static class CollectionExtensions
     /// <typeparam name="TSource">The type of the elements in the source collection.</typeparam>
     /// <param name="source">The source collection to split into chunks.</param>
     /// <param name="chunkSize">The size of each chunk.</param>
-    /// <returns>An <see cref="IEnumerable{T}"/> where each element is an array of elements of the specified chunk size.</returns>
+    /// <returns>An <see cref="IEnumerable{TSource}"/> where each element is an array of elements of the specified chunk size.</returns>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="chunkSize"/> is less than 1.</exception>
     public static IEnumerable<TSource[]> Chunk<TSource>(this IEnumerable<TSource> source, int chunkSize)
     {
@@ -45,13 +45,31 @@ public static class CollectionExtensions
 #endif
 
     /// <summary>
-    /// Performs the specified action on each element of the <see cref="IEnumerable{T}"/>.
+    /// Returns the elements of an <see cref="IEnumerable{TSource}"/>, or an empty singleton collection if the sequence is <see langword="null"/>.
     /// </summary>
-    /// <typeparam name="T">The type of the data in the <code>source</code>.</typeparam>
+    /// <typeparam name="TSource">The type of the data in the <code>source</code>.</typeparam>
+    /// <param name="source">The sequence to return a default value for if it is <see langword="null"/>.</param>
+    /// <returns>An empty <see cref="IEnumerable{TSource}"/> if source is <see langword="null"/>; otherwise, <paramref name="source"/>.</returns>
+    public static IEnumerable<TSource> EmptyIfNull<TSource>(this IEnumerable<TSource>? source)
+        => source ?? [];
+
+    /// <summary>
+    /// Returns the elements of an <see cref="IQueryable{TSource}"/>, or an empty singleton collection if the sequence is <see langword="null"/>.
+    /// </summary>
+    /// <typeparam name="TSource">The type of the data in the <code>source</code>.</typeparam>
+    /// <param name="source">The sequence to return a default value for if it is <see langword="null"/>.</param>
+    /// <returns>An empty <see cref="IQueryable{TSource}"/> if source is <see langword="null"/>; otherwise, <paramref name="source"/>.</returns>
+    public static IQueryable<TSource> EmptyIfNull<TSource>(this IQueryable<TSource>? source)
+        => source ?? Array.Empty<TSource>().AsQueryable();
+
+    /// <summary>
+    /// Performs the specified action on each element of the <see cref="IEnumerable{TSource}"/>.
+    /// </summary>
+    /// <typeparam name="TSource">The type of the data in the <code>source</code>.</typeparam>
     /// <param name="source">The sequence on whose elements apply the <code>action</code> to.</param>
-    /// <param name="action">The <see cref="Action{T}"/> delegate to perform on each element of the collection.</param>
-    /// <returns>An <see cref="IEnumerable{T}"/> whose elements are the result of invoking the <code>action</code> on each element of <code>source</code>.</returns>
-    public static IEnumerable<T> ForEach<T>(this IEnumerable<T> source, Action<T> action)
+    /// <param name="action">The <see cref="Action{TSource}"/> delegate to perform on each element of the collection.</param>
+    /// <returns>An <see cref="IEnumerable{TSource}"/> whose elements are the result of invoking the <code>action</code> on each element of <code>source</code>.</returns>
+    public static IEnumerable<TSource> ForEach<TSource>(this IEnumerable<TSource> source, Action<TSource> action)
     {
         foreach (var item in source)
         {
@@ -62,13 +80,13 @@ public static class CollectionExtensions
     }
 
     /// <summary>
-    /// Asynchronously performs the specified action on each element of the <see cref="IEnumerable{T}"/>.
+    /// Asynchronously performs the specified action on each element of the <see cref="IEnumerable{TSource}"/>.
     /// </summary>
     /// <typeparam name="TSource">The type of the data in the <code>source</code>.</typeparam>
     /// <param name="source">The sequence on whose elements apply the <code>action</code> to.</param>
     /// <param name="action">An asynchronous delegate that is invoked once per element in the data source.</param>
     /// <param name="cancellationToken">A token that can be used to request cancellation of the asynchronous operation.</param>
-    /// <returns>An <see cref="IEnumerable{T}" /> whose elements are the result of invoking the <code>action</code> on each element of <code>source</code>.</returns>
+    /// <returns>An <see cref="IEnumerable{TSource}" /> whose elements are the result of invoking the <code>action</code> on each element of <code>source</code>.</returns>
     public static async Task<IEnumerable<TSource>> ForEachAsync<TSource>(this IEnumerable<TSource> source, Func<TSource, Task> action, CancellationToken cancellationToken = default)
     {
         foreach (var item in source)
@@ -88,7 +106,7 @@ public static class CollectionExtensions
     /// <param name="source">A sequence of values to invoke a transform function on.</param>
     /// <param name="selector">A transform function to apply to each source element; the second parameter of the function represents the index of the source element.</param>
     /// <param name="cancellationToken">A token that can be used to request cancellation of the asynchronous operation.</param>
-    /// <returns>An <see cref="IEnumerable{T}" /> whose elements are the result of invoking the transform function on each element of <code>source</code>.</returns>
+    /// <returns>An <see cref="IEnumerable{TResult}" /> whose elements are the result of invoking the transform function on each element of <code>source</code>.</returns>
     /// <exception cref="ArgumentNullException"><code>source</code> is <code>null</code></exception>    
     public static async Task<IEnumerable<TResult>> SelectAsync<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, Task<TResult>> selector, CancellationToken cancellationToken = default)
     {
@@ -103,12 +121,12 @@ public static class CollectionExtensions
     }
 
     /// <summary>
-    /// Creates an <see cref="IEnumerable{T}"/> from an <see cref="IAsyncEnumerable{T}"/>.
+    /// Creates an <see cref="IEnumerable{TSource}"/> from an <see cref="IAsyncEnumerable{TSource}"/>.
     /// </summary>
     /// <typeparam name="TSource">The type of the elements of <code>source</code>.</typeparam>
-    /// <param name="source">The <see cref="IAsyncEnumerable{T}"/> to create a <see cref="IEnumerable{T}"/> from.</param>
+    /// <param name="source">The <see cref="IAsyncEnumerable{TSource}"/> to create a <see cref="IEnumerable{TSource}"/> from.</param>
     /// <param name="cancellationToken">A token that can be used to request cancellation of the asynchronous operation.</param>
-    /// <returns>An <see cref="IEnumerable{T}"/> that contains elements from the input sequence.</returns>
+    /// <returns>An <see cref="IEnumerable{TSource}"/> that contains elements from the input sequence.</returns>
     public static async ValueTask<IEnumerable<TSource>> ToListAsync<TSource>(this IAsyncEnumerable<TSource> source, CancellationToken cancellationToken = default)
     {
         var list = new List<TSource>();
@@ -124,7 +142,7 @@ public static class CollectionExtensions
     /// Removes from a collection all the elements that match the criteria specified by the <paramref name="predicate"/>.
     /// </summary>
     /// <typeparam name="TSource">The type of the elements.</typeparam>
-    /// <param name="collection">The <see cref="ICollection{T}"/> to remove elements from.</param>
+    /// <param name="collection">The <see cref="ICollection{TSource}"/> to remove elements from.</param>
     /// <param name="predicate">The delegate function that defines the conditions of the elements to remove.</param>
     public static void Remove<TSource>(this ICollection<TSource> collection, Func<TSource, bool> predicate)
     {
@@ -139,12 +157,12 @@ public static class CollectionExtensions
     }
 
     /// <summary>
-    /// Creates an <see cref="IEnumerable{T}"/> of <see cref="TinyHelpers.WithIndex{TValue}"/> elements from an <see cref="IEnumerable{T}"/>.
+    /// Creates an <see cref="IEnumerable{TSource}"/> of <see cref="TinyHelpers.WithIndex{TSource}"/> elements from an <see cref="IEnumerable{TSource}"/>.
     /// </summary>
     /// <typeparam name="TSource">The type of the elements.</typeparam>
-    /// <param name="source">The <see cref="IEnumerable{T}"/> to create an <see cref="IEnumerable{T}"/> of <see cref="TinyHelpers.WithIndex{TValue}"/> elements from.</param>
-    /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="TinyHelpers.WithIndex{TValue}"/> elements that contains projected elements from the input sequence.</returns>
-    /// <seealso cref="TinyHelpers.WithIndex{TValue}"/>
+    /// <param name="source">The <see cref="IEnumerable{TSource}"/> to create an <see cref="IEnumerable{TSource}"/> of <see cref="TinyHelpers.WithIndex{TSource}"/> elements from.</param>
+    /// <returns>An <see cref="IEnumerable{TSource}"/> of <see cref="TinyHelpers.WithIndex{TSource}"/> elements that contains projected elements from the input sequence.</returns>
+    /// <seealso cref="TinyHelpers.WithIndex{TSource}"/>
 #if NET9_0_OR_GREATER
     [EditorBrowsable(EditorBrowsableState.Never)]
     [Obsolete("The WithIndex() method is obsolete. Please use Index() instead.")]
@@ -153,12 +171,12 @@ public static class CollectionExtensions
         => source.Select((item, index) => new WithIndex<TSource>(item, index));
 
     /// <summary>
-    /// Creates an <see cref="IQueryable{T}"/> of <see cref="TinyHelpers.WithIndex{TValue}"/> elements from an <see cref="IQueryable{T}"/>.
+    /// Creates an <see cref="IQueryable{TSource}"/> of <see cref="TinyHelpers.WithIndex{TSource}"/> elements from an <see cref="IQueryable{TSource}"/>.
     /// </summary>
     /// <typeparam name="TSource">The type of the elements.</typeparam>
-    /// <param name="source">The <see cref="IQueryable{T}"/> to create an <see cref="IEnumerable{T}"/> of <see cref="TinyHelpers.WithIndex{TValue}"/> elements from.</param>
-    /// <returns>An <see cref="IQueryable{T}"/> of <see cref="TinyHelpers.WithIndex{TValue}"/> elements that contains projected elements from the input sequence.</returns>
-    /// <seealso cref="TinyHelpers.WithIndex{TValue}"/>
+    /// <param name="source">The <see cref="IQueryable{TSource}"/> to create an <see cref="IQueryable{TSource}"/> of <see cref="TinyHelpers.WithIndex{TSource}"/> elements from.</param>
+    /// <returns>An <see cref="IQueryable{T}"/> of <see cref="TinyHelpers.WithIndex{TSource}"/> elements that contains projected elements from the input sequence.</returns>
+    /// <seealso cref="TinyHelpers.WithIndex{TSource}"/>
 #if NET9_0_OR_GREATER
     [EditorBrowsable(EditorBrowsableState.Never)]
     [Obsolete("The WithIndex() method is obsolete. Please use Index() instead.")]
@@ -170,7 +188,7 @@ public static class CollectionExtensions
     /// Gets a value that indicates whether the <paramref name="source"/> collection is empty.
     /// </summary>
     /// <typeparam name="TSource">The type of the elements.</typeparam>
-    /// <param name="source">The <see cref="IEnumerable{T}"/> to check.</param>    
+    /// <param name="source">The <see cref="IEnumerable{TSource}"/> to check.</param>    
     /// <returns><see langword="true"/> if <paramref name="source"/> is empty; otherwise, <see langword="false"/>.</returns>
     public static bool IsEmpty<TSource>(this IEnumerable<TSource> source)
         => !source.Any();
@@ -179,7 +197,7 @@ public static class CollectionExtensions
     /// Gets a value that indicates whether the <paramref name="source"/> collection is not empty.
     /// </summary>
     /// <typeparam name="TSource">The type of the elements.</typeparam>
-    /// <param name="source">The <see cref="IEnumerable{T}"/> to check.</param>    
+    /// <param name="source">The <see cref="IEnumerable{TSource}"/> to check.</param>    
     /// <returns><see langword="true"/> if <paramref name="source"/> is not empty; otherwise, <see langword="false"/>.</returns>
     public static bool IsNotEmpty<TSource>(this IEnumerable<TSource> source)
         => source.Any();
@@ -188,7 +206,7 @@ public static class CollectionExtensions
     /// Gets a value that indicates whether the <paramref name="source"/> collection is <see langword="null"/> or empty.
     /// </summary>
     /// <typeparam name="TSource">The type of the elements.</typeparam>
-    /// <param name="source">The <see cref="IEnumerable{T}"/> to check.</param>    
+    /// <param name="source">The <see cref="IEnumerable{TSource}"/> to check.</param>    
     /// <returns><see langword="true"/> if <paramref name="source"/> is <see langword="null"/> or empty; otherwise, <see langword="false"/>.</returns>
     public static bool IsNullOrEmpty<TSource>([NotNullWhen(false)] this IEnumerable<TSource>? source)
         => !source?.Any() ?? true;
@@ -197,7 +215,7 @@ public static class CollectionExtensions
     /// Gets a value that indicates whether the <paramref name="source"/> collection is not <see langword="null"/> or empty.
     /// </summary>
     /// <typeparam name="TSource">The type of the elements.</typeparam>
-    /// <param name="source">The <see cref="IEnumerable{T}"/> to check.</param>    
+    /// <param name="source">The <see cref="IEnumerable{TSource}"/> to check.</param>    
     /// <returns><see langword="true"/> if the <paramref name="source"/> is not <see langword="null"/> and not empty; otherwise, <see langword="false"/>.</returns>
     public static bool IsNotNullOrEmpty<TSource>([NotNullWhen(true)] this IEnumerable<TSource>? source)
         => source?.Any() ?? false;
@@ -206,7 +224,7 @@ public static class CollectionExtensions
     /// Gets a value that indicates whether the <paramref name="source"/> collection contains items.
     /// </summary>
     /// <typeparam name="TSource">The type of the elements.</typeparam>
-    /// <param name="source">The <see cref="IEnumerable{T}"/> to check.</param>    
+    /// <param name="source">The <see cref="IEnumerable{TSource}"/> to check.</param>    
     /// <returns><see langword="true"/> if the <paramref name="source"/> is not <see langword="null"/> and contains any item; otherwise, <see langword="false"/>.</returns>
     public static bool HasItems<TSource>([NotNullWhen(true)] this IEnumerable<TSource>? source)
         => source.IsNotNullOrEmpty();
@@ -215,7 +233,7 @@ public static class CollectionExtensions
     /// Gets the number of elements in the <paramref name="source"/> collection.
     /// </summary>
     /// <typeparam name="TSource">The type of the elements.</typeparam>
-    /// <param name="source">The <see cref="IEnumerable{T}"/> to check.</param>    
+    /// <param name="source">The <see cref="IEnumerable{TSource}"/> to check.</param>    
     /// <param name="predicate">The delegate function that defines the conditions of the elements to consider for the count.</param>
     /// <returns>A <see cref="int"/> representing the number of elements that meet the criteria defined by the <paramref name="predicate"/> function, if not <see langword="null"/>; the number of elements in <paramref name="source"/>, otherwise.</returns>
     public static int GetCount<TSource>(this IEnumerable<TSource>? source, Func<TSource, bool>? predicate = null)
@@ -225,7 +243,7 @@ public static class CollectionExtensions
     /// Gets the number of elements in the <paramref name="source"/> collection.
     /// </summary>
     /// <typeparam name="TSource">The type of the elements.</typeparam>
-    /// <param name="source">The <see cref="IEnumerable{T}"/> to check.</param>    
+    /// <param name="source">The <see cref="IEnumerable{TSource}"/> to check.</param>    
     /// <param name="predicate">The delegate function that defines the conditions of the elements to consider for the count.</param>
     /// <returns>A <see cref="long"/> representing the number of elements that meet the criteria defined by the <paramref name="predicate"/> function, if not <see langword="null"/>; the number of elements in <paramref name="source"/>, otherwise.</returns>
     public static long GetLongCount<TSource>(this IEnumerable<TSource>? source, Func<TSource, bool>? predicate = null)
@@ -235,10 +253,10 @@ public static class CollectionExtensions
     /// Filters a sequence of values based on a condition.
     /// </summary>
     /// <typeparam name="TSource">The type of the elements.</typeparam>
-    /// <param name="source">The <see cref="IEnumerable{T}"/> to check.</param>    
+    /// <param name="source">The <see cref="IEnumerable{TSource}"/> to check.</param>    
     /// <param name="condition">A flag indicating whether the <paramref name="predicate"/> function filter should be applied.</param>
     /// <param name="predicate">The delegate function that defines the conditions of the elements to filter.</param>
-    /// <returns>An <see cref="IEnumerable{T}"/> that contains elements from the input sequence that satisfy the condition specified by <paramref name="predicate"/>; the unfiltered <paramref name="source"/>, otherwise.</returns>
+    /// <returns>An <see cref="IEnumerable{TSource}"/> that contains elements from the input sequence that satisfy the condition specified by <paramref name="predicate"/>; the unfiltered <paramref name="source"/>, otherwise.</returns>
     public static IEnumerable<TSource> WhereIf<TSource>(this IEnumerable<TSource> source, bool condition, Func<TSource, bool> predicate)
         => condition ? source.Where(predicate) : source;
 
@@ -246,10 +264,10 @@ public static class CollectionExtensions
     /// Filters a sequence of values based on a condition.
     /// </summary>
     /// <typeparam name="TSource">The type of the elements.</typeparam>
-    /// <param name="source">The <see cref="IQueryable{T}"/> to check.</param>    
+    /// <param name="source">The <see cref="IQueryable{TSource}"/> to check.</param>    
     /// <param name="condition">A flag indicating whether the <paramref name="predicate"/> expression filter should be applied.</param>
     /// <param name="predicate">The lambda expression that defines the conditions of the elements to filter.</param>
-    /// <returns>An <see cref="IQueryable{T}"/> that contains elements from the input sequence that satisfy the condition specified by <paramref name="predicate"/>; the unfiltered <paramref name="source"/>, otherwise.</returns>
+    /// <returns>An <see cref="IQueryable{TSource}"/> that contains elements from the input sequence that satisfy the condition specified by <paramref name="predicate"/>; the unfiltered <paramref name="source"/>, otherwise.</returns>
     public static IQueryable<TSource> WhereIf<TSource>(this IQueryable<TSource> source, bool condition, Expression<Func<TSource, bool>> predicate)
         => condition ? source.Where(predicate) : source;
 }


### PR DESCRIPTION
- Introduced `EmptyIfNull` methods for `IEnumerable<TSource>` and `IQueryable<TSource>`.

Closes #247