### PR TITLE
Update libraries

### DIFF
--- a/samples/TinyHelpers.AspNetCore.Sample/Program.cs
+++ b/samples/TinyHelpers.AspNetCore.Sample/Program.cs
@@ -35,7 +35,7 @@ builder.Services.AddOpenApiOperationParameters(options =>
 
     options.Parameters.Add(new()
     {
-        Name = "version",
+        Name = "Version",
         In = ParameterLocation.Query,
         Schema = OpenApiSchemaHelper.CreateSchema<int>("integer", "int32", 1)
     });
@@ -56,7 +56,10 @@ builder.Services.AddOpenApi(options =>
     options.RemoveServerList();
 
     // Fix the ignored JsonNumberHandling attribute.
-    options.AddWriteNumberAsStringSupport();
+    options.WriteNumberAsString();
+
+    // Describe all query string parameters in Camel Case.
+    options.DescribeAllParametersInCamelCase();
 });
 
 // Add default problem details and exception handler.

--- a/samples/TinyHelpers.AspNetCore.Sample/TinyHelpers.AspNetCore.Sample.csproj
+++ b/samples/TinyHelpers.AspNetCore.Sample/TinyHelpers.AspNetCore.Sample.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="7.3.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="7.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/TinyHelpers.AspNetCore8.Sample/TinyHelpers.AspNetCore8.Sample.csproj
+++ b/samples/TinyHelpers.AspNetCore8.Sample/TinyHelpers.AspNetCore8.Sample.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="[8.0.13,9.0.0)" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TinyHelpers.AspNetCore.Swashbuckle/TinyHelpers.AspNetCore.Swashbuckle.csproj
+++ b/src/TinyHelpers.AspNetCore.Swashbuckle/TinyHelpers.AspNetCore.Swashbuckle.csproj
@@ -26,7 +26,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="7.3.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="7.3.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/TinyHelpers.AspNetCore/OpenApi/OpenApiExtensions.cs
+++ b/src/TinyHelpers.AspNetCore/OpenApi/OpenApiExtensions.cs
@@ -44,8 +44,11 @@ public static class OpenApiExtensions
     public static OpenApiOptions RemoveServerList(this OpenApiOptions options)
         => options.AddDocumentTransformer<RemoveServerListDocumentTransformer>();
 
-    public static OpenApiOptions AddWriteNumberAsStringSupport(this OpenApiOptions options)
+    public static OpenApiOptions WriteNumberAsString(this OpenApiOptions options)
         => options.AddSchemaTransformer<WriteNumberAsStringSchemaTransformer>();
+
+    public static OpenApiOptions DescribeAllParametersInCamelCase(this OpenApiOptions options)
+        => options.AddOperationTransformer<CamelCaseQueryParametersOperationTransformer>();
 }
 
 #endif

--- a/src/TinyHelpers.AspNetCore/OpenApi/Transformers/CamelCaseQueryParametersOperationTransformer.cs
+++ b/src/TinyHelpers.AspNetCore/OpenApi/Transformers/CamelCaseQueryParametersOperationTransformer.cs
@@ -1,0 +1,26 @@
+﻿#if NET9_0_OR_GREATER
+
+using System.Text.Json;
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi.Models;
+
+namespace TinyHelpers.AspNetCore.OpenApi.Transformers;
+
+public class CamelCaseQueryParametersOperationTransformer : IOpenApiOperationTransformer
+{
+    public Task TransformAsync(OpenApiOperation operation, OpenApiOperationTransformerContext context, CancellationToken cancellationToken)
+    {
+        // Ensures that query parameters are camel-cased in the OpenAPI document.
+        if (operation.Parameters is not null)
+        {
+            foreach (var parameter in operation.Parameters.Where(p => p.In is ParameterLocation.Query))
+            {
+                parameter.Name = JsonNamingPolicy.CamelCase.ConvertName(parameter.Name);
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+}
+
+#endif

--- a/src/TinyHelpers.Dapper/TinyHelpers.Dapper.csproj
+++ b/src/TinyHelpers.Dapper/TinyHelpers.Dapper.csproj
@@ -22,7 +22,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Dapper" Version="2.1.66" />		
-		<PackageReference Include="TinyHelpers" Version="3.2.20" />
+		<PackageReference Include="TinyHelpers" Version="3.2.21" />
 	</ItemGroup>
 
     <ItemGroup>

--- a/src/TinyHelpers.EntityFrameworkCore/TinyHelpers.EntityFrameworkCore.csproj
+++ b/src/TinyHelpers.EntityFrameworkCore/TinyHelpers.EntityFrameworkCore.csproj
@@ -21,7 +21,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>		
-		<PackageReference Include="TinyHelpers" Version="3.2.20" />
+		<PackageReference Include="TinyHelpers" Version="3.2.21" />
 	</ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">


### PR DESCRIPTION
This pull request includes several updates and improvements across multiple files, focusing on package upgrades, method renaming, and new functionalities for handling OpenAPI parameters.

### Package Upgrades:
* Updated `Swashbuckle.AspNetCore.SwaggerUI` to version 7.3.1 in `TinyHelpers.AspNetCore.Sample.csproj`.
* Updated `Swashbuckle.AspNetCore` to version 7.3.1 in `TinyHelpers.AspNetCore8.Sample.csproj`.
* Updated `Swashbuckle.AspNetCore.SwaggerGen` to version 7.3.1 in `TinyHelpers.AspNetCore.Swashbuckle.csproj`.
* Updated `TinyHelpers` to version 3.2.21 in `TinyHelpers.Dapper.csproj` [[1]](diffhunk://#diff-a5e600d5a0bec6a3a1868d6104e2a782b57b725a53fea5d52c682fb58a3b0987L25-R25) and `TinyHelpers.EntityFrameworkCore.csproj` [[2]](diffhunk://#diff-6cb818b6e59a513f8a0ede12f92eb2cdb120526af82a5e520850eba0e74e976dL24-R24).

### Method Renaming and New Functionalities:
* Renamed method `AddWriteNumberAsStringSupport` to `WriteNumberAsString` and added a new method `DescribeAllParametersInCamelCase` in `OpenApiExtensions.cs`.
* Added a transformer class `CamelCaseQueryParametersOperationTransformer` to ensure query parameters are camel-cased in the OpenAPI document.

### Specific Changes in `Program.cs`:
* Corrected the casing of a parameter from "version" to "Version".
* Replaced `AddWriteNumberAsStringSupport` with `WriteNumberAsString` and added a call to `DescribeAllParametersInCamelCase`.