### PR TITLE
Add default language support in OpenAPI filters

### DIFF
--- a/src/TinyHelpers.AspNetCore.Swashbuckle/Filters/AcceptLanguageHeaderOperationFilter.cs
+++ b/src/TinyHelpers.AspNetCore.Swashbuckle/Filters/AcceptLanguageHeaderOperationFilter.cs
@@ -10,9 +10,11 @@ namespace TinyHelpers.AspNetCore.Swagger.Filters;
 internal class AcceptLanguageHeaderOperationFilter(IOptions<RequestLocalizationOptions> requestLocalizationOptions) : IOperationFilter
 {
     private readonly List<IOpenApiAny>? supportedLanguages = requestLocalizationOptions.Value
-            .SupportedCultures?.Select(c => new OpenApiString(c.TwoLetterISOLanguageName))
+            .SupportedCultures?.Select(c => new OpenApiString(c.Name))
             .Cast<IOpenApiAny>()
             .ToList();
+
+    private readonly IOpenApiAny defaultLanguage = new OpenApiString(requestLocalizationOptions.Value.DefaultRequestCulture.Culture.Name);
 
     public void Apply(OpenApiOperation operation, OperationFilterContext context)
     {
@@ -31,7 +33,7 @@ internal class AcceptLanguageHeaderOperationFilter(IOptions<RequestLocalizationO
                     {
                         Type = "string",
                         Enum = supportedLanguages,
-                        Default = supportedLanguages.First()
+                        Default = defaultLanguage
                     }
                 });
             }

--- a/src/TinyHelpers.AspNetCore/OpenApi/Transformers/AcceptLanguageHeaderOperationTransformer.cs
+++ b/src/TinyHelpers.AspNetCore/OpenApi/Transformers/AcceptLanguageHeaderOperationTransformer.cs
@@ -12,9 +12,11 @@ namespace TinyHelpers.AspNetCore.OpenApi;
 internal class AcceptLanguageHeaderOperationTransformer(IOptions<RequestLocalizationOptions> requestLocalizationOptions) : IOpenApiOperationTransformer
 {
     private readonly List<IOpenApiAny>? supportedLanguages = requestLocalizationOptions.Value
-            .SupportedCultures?.Select(c => new OpenApiString(c.TwoLetterISOLanguageName))
+            .SupportedCultures?.Select(c => new OpenApiString(c.Name))
             .Cast<IOpenApiAny>()
             .ToList();
+
+    private readonly IOpenApiAny defaultLanguage = new OpenApiString(requestLocalizationOptions.Value.DefaultRequestCulture.Culture.Name);
 
     public Task TransformAsync(OpenApiOperation operation, OpenApiOperationTransformerContext context, CancellationToken cancellationToken)
     {
@@ -33,7 +35,7 @@ internal class AcceptLanguageHeaderOperationTransformer(IOptions<RequestLocaliza
                     {
                         Type = "string",
                         Enum = supportedLanguages,
-                        Default = supportedLanguages.First()
+                        Default = defaultLanguage
                     }
                 });
             }


### PR DESCRIPTION
Introduce a `defaultLanguage` field in both
`AcceptLanguageHeaderOperationFilter` and
`AcceptLanguageHeaderOperationTransformer` classes. This field is initialized with the default request culture's name. Update the OpenAPI schema to set
the `Default` property to `defaultLanguage`, ensuring the default language is explicitly defined based on the application's configuration.