### PR TITLE
Update Swashbuckle packages to version 8.1.0

### DIFF
--- a/samples/TinyHelpers.AspNetCore.Sample/TinyHelpers.AspNetCore.Sample.csproj
+++ b/samples/TinyHelpers.AspNetCore.Sample/TinyHelpers.AspNetCore.Sample.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/TinyHelpers.AspNetCore8.Sample/TinyHelpers.AspNetCore8.Sample.csproj
+++ b/samples/TinyHelpers.AspNetCore8.Sample/TinyHelpers.AspNetCore8.Sample.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="[8.0.14,9.0.0)" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TinyHelpers.AspNetCore.Swashbuckle/TinyHelpers.AspNetCore.Swashbuckle.csproj
+++ b/src/TinyHelpers.AspNetCore.Swashbuckle/TinyHelpers.AspNetCore.Swashbuckle.csproj
@@ -26,7 +26,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="8.0.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="8.1.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Updated the `Swashbuckle.AspNetCore.SwaggerUI` and `Swashbuckle.AspNetCore.SwaggerGen` packages from version `8.0.0` to `8.1.0` in their respective project files. Additionally, specified the `Microsoft.AspNetCore.OpenApi` package version range in `TinyHelpers.AspNetCore8.Sample.csproj` to be within `[8.0.14,9.0.0)`.