### PR TITLE
Update package versions for ASP.NET Core and JSON

### DIFF
--- a/samples/TinyHelpers.AspNetCore.Sample/TinyHelpers.AspNetCore.Sample.csproj
+++ b/samples/TinyHelpers.AspNetCore.Sample/TinyHelpers.AspNetCore.Sample.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.1.0" />
   </ItemGroup>
 

--- a/samples/TinyHelpers.AspNetCore8.Sample/TinyHelpers.AspNetCore8.Sample.csproj
+++ b/samples/TinyHelpers.AspNetCore8.Sample/TinyHelpers.AspNetCore8.Sample.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="[8.0.14,9.0.0)" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="[8.0.15,9.0.0)" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.0" />
   </ItemGroup>
 

--- a/src/TinyHelpers.AspNetCore/TinyHelpers.AspNetCore.csproj
+++ b/src/TinyHelpers.AspNetCore/TinyHelpers.AspNetCore.csproj
@@ -25,7 +25,7 @@
     </ItemGroup>
     
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.3" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
     </ItemGroup>    
 
     <ItemGroup>

--- a/src/TinyHelpers/TinyHelpers.csproj
+++ b/src/TinyHelpers/TinyHelpers.csproj
@@ -30,7 +30,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-        <PackageReference Include="System.Text.Json" Version="9.0.3" />
+        <PackageReference Include="System.Text.Json" Version="9.0.4" />
     </ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
- Bump `Microsoft.AspNetCore.OpenApi` to `9.0.4` in `TinyHelpers.AspNetCore.Sample.csproj` and `TinyHelpers.AspNetCore.csproj`.
- Bump `Microsoft.AspNetCore.OpenApi` to `[8.0.15,9.0.0)` in `TinyHelpers.AspNetCore8.Sample.csproj`.
- Upgrade `System.Text.Json` to `9.0.4` in `TinyHelpers.csproj`.