### PR TITLE
Add time examples and new API endpoint for TimeInput

### DIFF
--- a/samples/TinyHelpers.AspNetCore.Sample/Program.cs
+++ b/samples/TinyHelpers.AspNetCore.Sample/Program.cs
@@ -60,6 +60,9 @@ builder.Services.AddOpenApi(options =>
 
     // Describe all query string parameters in Camel Case.
     options.DescribeAllParametersInCamelCase();
+
+    // Add time examples for TimeSpan and TimeOnly fields.
+    //options.AddTimeExamples();
 });
 
 // Add default problem details and exception handler.
@@ -104,6 +107,11 @@ app.MapPost("/api/exception", () =>
 })
 .ProducesProblem(StatusCodes.Status400BadRequest);
 
+app.MapPost("/api/time", (TimeInput input) =>
+{
+    return TypedResults.Ok(input);
+});
+
 app.Run();
 
 public enum Environment
@@ -118,3 +126,5 @@ internal record RandomNumber()
     [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString | JsonNumberHandling.WriteAsString)]
     public int Number { get; init; } = Random.Shared.Next(0, 100);
 };
+
+public record class TimeInput(TimeSpan TimeSpan, TimeOnly TimeOnly);

--- a/samples/TinyHelpers.AspNetCore.Sample/Program.cs
+++ b/samples/TinyHelpers.AspNetCore.Sample/Program.cs
@@ -62,7 +62,7 @@ builder.Services.AddOpenApi(options =>
     options.DescribeAllParametersInCamelCase();
 
     // Add time examples for TimeSpan and TimeOnly fields.
-    //options.AddTimeExamples();
+    options.AddTimeExamples();
 });
 
 // Add default problem details and exception handler.
@@ -127,4 +127,4 @@ internal record RandomNumber()
     public int Number { get; init; } = Random.Shared.Next(0, 100);
 };
 
-public record class TimeInput(TimeSpan TimeSpan, TimeOnly TimeOnly);
+public record class TimeInput(TimeSpan? TimeSpan, TimeOnly? TimeOnly);

--- a/samples/TinyHelpers.AspNetCore.Sample/TinyHelpers.AspNetCore.Sample.csproj
+++ b/samples/TinyHelpers.AspNetCore.Sample/TinyHelpers.AspNetCore.Sample.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.1.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/TinyHelpers.AspNetCore8.Sample/TinyHelpers.AspNetCore8.Sample.csproj
+++ b/samples/TinyHelpers.AspNetCore8.Sample/TinyHelpers.AspNetCore8.Sample.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="[8.0.15,9.0.0)" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TinyHelpers.AspNetCore.Swashbuckle/TinyHelpers.AspNetCore.Swashbuckle.csproj
+++ b/src/TinyHelpers.AspNetCore.Swashbuckle/TinyHelpers.AspNetCore.Swashbuckle.csproj
@@ -26,7 +26,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="8.1.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="8.1.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/TinyHelpers.AspNetCore/OpenApi/OpenApiExtensions.cs
+++ b/src/TinyHelpers.AspNetCore/OpenApi/OpenApiExtensions.cs
@@ -49,6 +49,9 @@ public static class OpenApiExtensions
 
     public static OpenApiOptions DescribeAllParametersInCamelCase(this OpenApiOptions options)
         => options.AddOperationTransformer<CamelCaseQueryParametersOperationTransformer>();
+
+    public static OpenApiOptions AddTimeExamples(this OpenApiOptions options)
+        => options.AddSchemaTransformer<TimeExampleSchemaTransformer>();
 }
 
 #endif

--- a/src/TinyHelpers.AspNetCore/OpenApi/Transformers/TimeExampleSchemaTransformer.cs
+++ b/src/TinyHelpers.AspNetCore/OpenApi/Transformers/TimeExampleSchemaTransformer.cs
@@ -1,0 +1,22 @@
+﻿#if NET9_0_OR_GREATER
+
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+
+namespace TinyHelpers.AspNetCore.OpenApi.Transformers;
+
+public class TimeExampleSchemaTransformer : IOpenApiSchemaTransformer
+{
+    public Task TransformAsync(OpenApiSchema schema, OpenApiSchemaTransformerContext context, CancellationToken cancellationToken)
+    {
+        if (context.JsonTypeInfo.Type == typeof(TimeSpan) || context.JsonTypeInfo.Type == typeof(TimeOnly))
+        {
+            schema.Example = new OpenApiString(DateTime.Now.ToString("HH:mm:ss"));
+        }
+
+        return Task.CompletedTask;
+    }
+}
+
+#endif

--- a/src/TinyHelpers.AspNetCore/OpenApi/Transformers/TimeExampleSchemaTransformer.cs
+++ b/src/TinyHelpers.AspNetCore/OpenApi/Transformers/TimeExampleSchemaTransformer.cs
@@ -10,7 +10,8 @@ public class TimeExampleSchemaTransformer : IOpenApiSchemaTransformer
 {
     public Task TransformAsync(OpenApiSchema schema, OpenApiSchemaTransformerContext context, CancellationToken cancellationToken)
     {
-        if (context.JsonTypeInfo.Type == typeof(TimeSpan) || context.JsonTypeInfo.Type == typeof(TimeOnly))
+        var type = context.JsonTypeInfo.Type;
+        if (type == typeof(TimeSpan) || type == typeof(TimeSpan?) || type == typeof(TimeOnly) || type == typeof(TimeOnly?))
         {
             schema.Example = new OpenApiString(DateTime.Now.ToString("HH:mm:ss"));
         }


### PR DESCRIPTION
Updated `AddOpenApi` in `Program.cs` to include an option for time examples for `TimeSpan` and `TimeOnly`. Introduced a new record class `TimeInput` and added a new API endpoint `/api/time` to handle it. Updated the `Swashbuckle.AspNetCore` package version to `8.1.1` across multiple projects. Added `TimeExampleSchemaTransformer` to provide example values for time types in OpenAPI schemas and updated `OpenApiExtensions` to register this transformer.