### PR TITLE
Update package versions in project files

### DIFF
--- a/samples/TinyHelpers.EntityFrameworkCore.Sample/TinyHelpers.EntityFrameworkCore.Sample.csproj
+++ b/samples/TinyHelpers.EntityFrameworkCore.Sample/TinyHelpers.EntityFrameworkCore.Sample.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.4" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.5" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/TinyHelpers.Dapper/TinyHelpers.Dapper.csproj
+++ b/src/TinyHelpers.Dapper/TinyHelpers.Dapper.csproj
@@ -22,7 +22,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Dapper" Version="2.1.66" />		
-		<PackageReference Include="TinyHelpers" Version="3.2.24" />
+		<PackageReference Include="TinyHelpers" Version="3.2.25" />
 	</ItemGroup>
 
     <ItemGroup>

--- a/src/TinyHelpers.EntityFrameworkCore/TinyHelpers.EntityFrameworkCore.csproj
+++ b/src/TinyHelpers.EntityFrameworkCore/TinyHelpers.EntityFrameworkCore.csproj
@@ -21,15 +21,15 @@
 	</PropertyGroup>
 
 	<ItemGroup>		
-		<PackageReference Include="TinyHelpers" Version="3.2.24" />
+		<PackageReference Include="TinyHelpers" Version="3.2.25" />
 	</ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.15" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.16" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.4" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.5" />
     </ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
- Bump `Microsoft.EntityFrameworkCore.SqlServer` to 9.0.5 in `TinyHelpers.EntityFrameworkCore.Sample.csproj`.
- Upgrade `TinyHelpers` package to 3.2.25 in `TinyHelpers.Dapper.csproj` and `TinyHelpers.EntityFrameworkCore.csproj`.
- Update `Microsoft.EntityFrameworkCore.Relational` to 8.0.16 for `net8.0` in `TinyHelpers.EntityFrameworkCore.csproj`.
- Update `Microsoft.EntityFrameworkCore.Relational` to 9.0.5 for `net9.0` in `TinyHelpers.EntityFrameworkCore.csproj`.