### PR TITLE
Update package versions across multiple projects

### DIFF
--- a/samples/TinyHelpers.AspNetCore.Sample/TinyHelpers.AspNetCore.Sample.csproj
+++ b/samples/TinyHelpers.AspNetCore.Sample/TinyHelpers.AspNetCore.Sample.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.1.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/TinyHelpers.AspNetCore8.Sample/TinyHelpers.AspNetCore8.Sample.csproj
+++ b/samples/TinyHelpers.AspNetCore8.Sample/TinyHelpers.AspNetCore8.Sample.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="[8.0.16,9.0.0)" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/TinyHelpers.Sample/TinyHelpers.Sample.csproj
+++ b/samples/TinyHelpers.Sample/TinyHelpers.Sample.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+	  <PackageReference Include="BenchmarkDotNet" Version="0.15.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/TinyHelpers.AspNetCore.Swashbuckle/TinyHelpers.AspNetCore.Swashbuckle.csproj
+++ b/src/TinyHelpers.AspNetCore.Swashbuckle/TinyHelpers.AspNetCore.Swashbuckle.csproj
@@ -26,7 +26,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="8.1.1" />
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="8.1.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/TinyHelpers.Tests/TinyHelpers.Tests.csproj
+++ b/tests/TinyHelpers.Tests/TinyHelpers.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
- Upgraded `Swashbuckle.AspNetCore.SwaggerUI` to `8.1.2` in `TinyHelpers.AspNetCore.Sample.csproj`.
- Upgraded `Swashbuckle.AspNetCore` to `8.1.2` in `TinyHelpers.AspNetCore8.Sample.csproj`.
- Upgraded `BenchmarkDotNet` to `0.15.0` in `TinyHelpers.Sample.csproj`.
- Upgraded `Swashbuckle.AspNetCore.SwaggerGen` to `8.1.2` in `TinyHelpers.AspNetCore.Swashbuckle.csproj`.
- Upgraded `Microsoft.NET.Test.Sdk` to `17.14.0` in `TinyHelpers.Tests.csproj`.