### PR TITLE
Update package versions across multiple projects

### DIFF
--- a/samples/TinyHelpers.AspNetCore.Sample/TinyHelpers.AspNetCore.Sample.csproj
+++ b/samples/TinyHelpers.AspNetCore.Sample/TinyHelpers.AspNetCore.Sample.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.6" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.1.4" />
   </ItemGroup>
 

--- a/samples/TinyHelpers.AspNetCore8.Sample/TinyHelpers.AspNetCore8.Sample.csproj
+++ b/samples/TinyHelpers.AspNetCore8.Sample/TinyHelpers.AspNetCore8.Sample.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="[8.0.16,9.0.0)" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="[8.0.17,9.0.0)" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.4" />
   </ItemGroup>
 

--- a/samples/TinyHelpers.Sample/TinyHelpers.Sample.csproj
+++ b/samples/TinyHelpers.Sample/TinyHelpers.Sample.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="BenchmarkDotNet" Version="0.15.0" />
+	  <PackageReference Include="BenchmarkDotNet" Version="0.15.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/TinyHelpers.AspNetCore/TinyHelpers.AspNetCore.csproj
+++ b/src/TinyHelpers.AspNetCore/TinyHelpers.AspNetCore.csproj
@@ -25,7 +25,7 @@
     </ItemGroup>
     
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.6" />
     </ItemGroup>    
 
     <ItemGroup>

--- a/src/TinyHelpers/TinyHelpers.csproj
+++ b/src/TinyHelpers/TinyHelpers.csproj
@@ -30,7 +30,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-        <PackageReference Include="System.Text.Json" Version="9.0.5" />
+        <PackageReference Include="System.Text.Json" Version="9.0.6" />
     </ItemGroup>
 
 	<ItemGroup>

--- a/tests/TinyHelpers.Tests/TinyHelpers.Tests.csproj
+++ b/tests/TinyHelpers.Tests/TinyHelpers.Tests.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
- Bump `Microsoft.AspNetCore.OpenApi` to `9.0.6` in `TinyHelpers.AspNetCore.Sample.csproj` and `TinyHelpers.AspNetCore.csproj`.
- Adjust version range for `Microsoft.AspNetCore.OpenApi` to `[8.0.17,9.0.0)` in `TinyHelpers.AspNetCore8.Sample.csproj`.
- Upgrade `BenchmarkDotNet` to `0.15.1` in `TinyHelpers.Sample.csproj`.
- Update `System.Text.Json` to `9.0.6` in `TinyHelpers.csproj`.
- Upgrade `Microsoft.NET.Test.Sdk` to `17.14.1` and `xunit.runner.visualstudio` to `3.1.1` in `TinyHelpers.Tests.csproj`.