### PR TITLE
Update package references in project files

### DIFF
--- a/samples/TinyHelpers.EntityFrameworkCore.Sample/TinyHelpers.EntityFrameworkCore.Sample.csproj
+++ b/samples/TinyHelpers.EntityFrameworkCore.Sample/TinyHelpers.EntityFrameworkCore.Sample.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.5" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.6" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/TinyHelpers.Dapper/TinyHelpers.Dapper.csproj
+++ b/src/TinyHelpers.Dapper/TinyHelpers.Dapper.csproj
@@ -22,7 +22,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Dapper" Version="2.1.66" />		
-		<PackageReference Include="TinyHelpers" Version="3.2.25" />
+		<PackageReference Include="TinyHelpers" Version="3.2.26" />
 	</ItemGroup>
 
     <ItemGroup>

--- a/src/TinyHelpers.EntityFrameworkCore/TinyHelpers.EntityFrameworkCore.csproj
+++ b/src/TinyHelpers.EntityFrameworkCore/TinyHelpers.EntityFrameworkCore.csproj
@@ -21,15 +21,15 @@
 	</PropertyGroup>
 
 	<ItemGroup>		
-		<PackageReference Include="TinyHelpers" Version="3.2.25" />
+		<PackageReference Include="TinyHelpers" Version="3.2.26" />
 	</ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.16" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.17" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.5" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.6" />
     </ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
- Updated `Microsoft.EntityFrameworkCore.SqlServer` to version 9.0.6 in `TinyHelpers.EntityFrameworkCore.Sample.csproj`.
- Updated `TinyHelpers` package to version 3.2.26 in `TinyHelpers.Dapper.csproj` and `TinyHelpers.EntityFrameworkCore.csproj`.
- Updated `Microsoft.EntityFrameworkCore.Relational` to version 8.0.17 for `net8.0` and 9.0.6 for `net9.0` in `TinyHelpers.EntityFrameworkCore.csproj`.