### PR TITLE
Update package versions for ASP.NET Core and JSON

### DIFF
--- a/src/TinyHelpers.AspNetCore/TinyHelpers.AspNetCore.csproj
+++ b/src/TinyHelpers.AspNetCore/TinyHelpers.AspNetCore.csproj
@@ -25,7 +25,7 @@
     </ItemGroup>
     
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.9" />
     </ItemGroup>    
 
     <ItemGroup>

--- a/src/TinyHelpers/TinyHelpers.csproj
+++ b/src/TinyHelpers/TinyHelpers.csproj
@@ -30,7 +30,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-        <PackageReference Include="System.Text.Json" Version="9.0.8" />
+        <PackageReference Include="System.Text.Json" Version="9.0.9" />
     </ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Updated the `Microsoft.AspNetCore.OpenApi` package from version `9.0.8` to `9.0.9` in `TinyHelpers.AspNetCore.csproj`.

Updated the `System.Text.Json` package from version `9.0.8` to `9.0.9` in `TinyHelpers.csproj`.