### PR TITLE
Update package versions across multiple projects

### DIFF
--- a/samples/TinyHelpers.AspNetCore.Sample/TinyHelpers.AspNetCore.Sample.csproj
+++ b/samples/TinyHelpers.AspNetCore.Sample/TinyHelpers.AspNetCore.Sample.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.9" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.4" />
   </ItemGroup>
 

--- a/samples/TinyHelpers.AspNetCore8.Sample/TinyHelpers.AspNetCore8.Sample.csproj
+++ b/samples/TinyHelpers.AspNetCore8.Sample/TinyHelpers.AspNetCore8.Sample.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="[8.0.19,9.0.0)" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="[8.0.20,9.0.0)" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.4" />
   </ItemGroup>
 

--- a/samples/TinyHelpers.EntityFrameworkCore.Sample/TinyHelpers.EntityFrameworkCore.Sample.csproj
+++ b/samples/TinyHelpers.EntityFrameworkCore.Sample/TinyHelpers.EntityFrameworkCore.Sample.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.9" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/TinyHelpers.Dapper/TinyHelpers.Dapper.csproj
+++ b/src/TinyHelpers.Dapper/TinyHelpers.Dapper.csproj
@@ -22,7 +22,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Dapper" Version="2.1.66" />		
-		<PackageReference Include="TinyHelpers" Version="3.3.6" />
+		<PackageReference Include="TinyHelpers" Version="3.3.7" />
 	</ItemGroup>
 
     <ItemGroup>

--- a/src/TinyHelpers.EntityFrameworkCore/TinyHelpers.EntityFrameworkCore.csproj
+++ b/src/TinyHelpers.EntityFrameworkCore/TinyHelpers.EntityFrameworkCore.csproj
@@ -21,15 +21,15 @@
 	</PropertyGroup>
 
 	<ItemGroup>		
-		<PackageReference Include="TinyHelpers" Version="3.3.6" />
+		<PackageReference Include="TinyHelpers" Version="3.3.7" />
 	</ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.19" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.20" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.8" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.9" />
     </ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
- Bump `Microsoft.AspNetCore.OpenApi` to `9.0.9` in `TinyHelpers.AspNetCore.Sample.csproj`.
- Bump `Microsoft.AspNetCore.OpenApi` to `[8.0.20,9.0.0)` in `TinyHelpers.AspNetCore8.Sample.csproj`.
- Bump `Microsoft.EntityFrameworkCore.SqlServer` to `9.0.9` in `TinyHelpers.EntityFrameworkCore.Sample.csproj`.
- Update `TinyHelpers` package to `3.3.7` in `TinyHelpers.Dapper.csproj`.
- Update `TinyHelpers` package to `3.3.7` in `TinyHelpers.EntityFrameworkCore.csproj`.
- Bump `Microsoft.EntityFrameworkCore.Relational` to `8.0.20` for `net8.0` in `TinyHelpers.EntityFrameworkCore.csproj`.
- Bump `Microsoft.EntityFrameworkCore.Relational` to `9.0.9` for `net9.0` in `TinyHelpers.EntityFrameworkCore.csproj`.