### PR TITLE
Update .editorconfig and package versions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -82,6 +82,7 @@ csharp_style_prefer_local_over_anonymous_function = true:silent
 csharp_style_prefer_extended_property_pattern = true:suggestion
 csharp_style_implicit_object_creation_when_type_is_apparent = true:silent
 csharp_style_prefer_tuple_swap = true:silent
+csharp_style_prefer_simple_property_accessors = true:suggestion
 
 # Field preferences
 dotnet_style_readonly_field = true:suggestion
@@ -300,3 +301,6 @@ dotnet_diagnostic.IDE0072.severity = none
 
 # IDE0305: Simplify collection initialization
 dotnet_diagnostic.IDE0305.severity = none
+
+# CA1873: Avoid potentially expensive logging
+dotnet_diagnostic.CA1873.severity = none

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -59,7 +59,7 @@
 ### Implementation Guidelines
 
 - Write code that is secure by default. Avoid exposing potentially private or sensitive data.
-- Make code NativeAOT compatible when possible. This means avoiding dynamic code generation, reflection, and other features that are not compatible. with NativeAOT. If not possible, mark the code with an appropriate annotation or throw an exception.
+- Make code NativeAOT compatible when possible. This means avoiding dynamic code generation, reflection, and other features that are not compatible with NativeAOT. If not possible, mark the code with an appropriate annotation or throw an exception.
 
 ## Documentation
 

--- a/samples/TinyHelpers.AspNetCore.Sample/TinyHelpers.AspNetCore.Sample.csproj
+++ b/samples/TinyHelpers.AspNetCore.Sample/TinyHelpers.AspNetCore.Sample.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.9" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.10" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/TinyHelpers.AspNetCore8.Sample/TinyHelpers.AspNetCore8.Sample.csproj
+++ b/samples/TinyHelpers.AspNetCore8.Sample/TinyHelpers.AspNetCore8.Sample.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="[8.0.20,9.0.0)" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="[8.0.21,9.0.0)" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/TinyHelpers.Dapper.Sample/TinyHelpers.Dapper.Sample.csproj
+++ b/samples/TinyHelpers.Dapper.Sample/TinyHelpers.Dapper.Sample.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/TinyHelpers.EntityFrameworkCore.Sample/TinyHelpers.EntityFrameworkCore.Sample.csproj
+++ b/samples/TinyHelpers.EntityFrameworkCore.Sample/TinyHelpers.EntityFrameworkCore.Sample.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.9" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.10" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/samples/TinyHelpers.Sample/TinyHelpers.Sample.csproj
+++ b/samples/TinyHelpers.Sample/TinyHelpers.Sample.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="BenchmarkDotNet" Version="0.15.2" />
+	  <PackageReference Include="BenchmarkDotNet" Version="0.15.4" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Nerdbank.GitVersioning" Version="3.7.115"  PrivateAssets="All" />
+        <PackageReference Include="Nerdbank.GitVersioning" Version="3.8.118"  PrivateAssets="All" />
     </ItemGroup>
 
 </Project>

--- a/src/TinyHelpers.AspNetCore.Swashbuckle/TinyHelpers.AspNetCore.Swashbuckle.csproj
+++ b/src/TinyHelpers.AspNetCore.Swashbuckle/TinyHelpers.AspNetCore.Swashbuckle.csproj
@@ -26,7 +26,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="9.0.4" />
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="9.0.6" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/TinyHelpers.AspNetCore/TinyHelpers.AspNetCore.csproj
+++ b/src/TinyHelpers.AspNetCore/TinyHelpers.AspNetCore.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
@@ -25,7 +25,7 @@
     </ItemGroup>
     
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.9" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.10" />
     </ItemGroup>    
 
     <ItemGroup>

--- a/src/TinyHelpers/TinyHelpers.csproj
+++ b/src/TinyHelpers/TinyHelpers.csproj
@@ -30,7 +30,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-        <PackageReference Include="System.Text.Json" Version="9.0.9" />
+        <PackageReference Include="System.Text.Json" Version="9.0.10" />
     </ItemGroup>
 
 	<ItemGroup>

--- a/tests/TinyHelpers.Tests/TinyHelpers.Tests.csproj
+++ b/tests/TinyHelpers.Tests/TinyHelpers.Tests.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Updated `.editorconfig` to add a new style preference for simple property accessors and set diagnostic severity for `CA1873` to `none`. Corrected a typo in `copilot-instructions.md`. Updated package references in multiple `.csproj` files to newer versions, including `Microsoft.AspNetCore.OpenApi`, `Swashbuckle.AspNetCore`, `Microsoft.Data.SqlClient`, and others. Fixed a formatting issue in `TinyHelpers.AspNetCore.csproj`.