### PR TITLE
Update package versions in project files

### DIFF
--- a/src/TinyHelpers.Dapper/TinyHelpers.Dapper.csproj
+++ b/src/TinyHelpers.Dapper/TinyHelpers.Dapper.csproj
@@ -22,7 +22,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Dapper" Version="2.1.66" />		
-		<PackageReference Include="TinyHelpers" Version="3.3.7" />
+		<PackageReference Include="TinyHelpers" Version="3.3.8" />
 	</ItemGroup>
 
     <ItemGroup>

--- a/src/TinyHelpers.EntityFrameworkCore/TinyHelpers.EntityFrameworkCore.csproj
+++ b/src/TinyHelpers.EntityFrameworkCore/TinyHelpers.EntityFrameworkCore.csproj
@@ -21,15 +21,15 @@
 	</PropertyGroup>
 
 	<ItemGroup>		
-		<PackageReference Include="TinyHelpers" Version="3.3.7" />
+		<PackageReference Include="TinyHelpers" Version="3.3.8" />
 	</ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.20" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.21" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.9" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.10" />
     </ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Updated the `TinyHelpers` package version from `3.3.7` to `3.3.8` in both `TinyHelpers.Dapper.csproj` and `TinyHelpers.EntityFrameworkCore.csproj` files. Additionally, updated the `Microsoft.EntityFrameworkCore.Relational` package version in `TinyHelpers.EntityFrameworkCore.csproj`:
- For `net8.0`, from `8.0.20` to `8.0.21`.
- For `net9.0`, from `9.0.9` to `9.0.10`.