### PR TITLE
Update TinyHelpers to version 3.3.9

### DIFF
--- a/src/TinyHelpers.Dapper/TinyHelpers.Dapper.csproj
+++ b/src/TinyHelpers.Dapper/TinyHelpers.Dapper.csproj
@@ -22,7 +22,7 @@
 
     <ItemGroup>
         <PackageReference Include="Dapper" Version="2.1.66" />
-        <PackageReference Include="TinyHelpers" Version="3.3.8" />
+        <PackageReference Include="TinyHelpers" Version="3.3.9" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/TinyHelpers.EntityFrameworkCore/TinyHelpers.EntityFrameworkCore.csproj
+++ b/src/TinyHelpers.EntityFrameworkCore/TinyHelpers.EntityFrameworkCore.csproj
@@ -21,7 +21,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>		
-		<PackageReference Include="TinyHelpers" Version="3.3.8" />
+		<PackageReference Include="TinyHelpers" Version="3.3.9" />
 	</ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">


### PR DESCRIPTION
Updated the `TinyHelpers` package dependency from version 3.3.8 to 3.3.9 in both `TinyHelpers.Dapper.csproj` and `TinyHelpers.EntityFrameworkCore.csproj`. This update may include bug fixes, improvements, or new features provided by the `TinyHelpers` library.

#286