### PR TITLE
Refactor ProducesDefaultProblem as static extension method

### DIFF
--- a/src/TinyHelpers.AspNetCore/Extensions/RouteHandlerBuilderExtensions.cs
+++ b/src/TinyHelpers.AspNetCore/Extensions/RouteHandlerBuilderExtensions.cs
@@ -12,24 +12,24 @@ namespace TinyHelpers.AspNetCore.Extensions;
 /// <seealso cref="RouteHandlerBuilder"/>
 public static class RouteHandlerBuilderExtensions
 {
-    extension(RouteHandlerBuilder builder)
+    /// <summary>
+    /// Adds to <see cref="RouteHandlerBuilder"/> the specified list of status codes as <see cref="ProblemDetails"/> responses.
+    /// </summary>
+    /// <param name="builder">The <see cref="RouteHandlerBuilder"/>.</param>
+    /// <param name="statusCodes">The list of status codes to be added as <see cref="ProblemDetails"/> responses.</param>
+    /// <returns>The <see cref="RouteHandlerBuilder"/> with the new status codes responses.</returns>
+    public static RouteHandlerBuilder ProducesDefaultProblem(this RouteHandlerBuilder builder, params int[] statusCodes)
     {
-        /// <summary>
-        /// Adds to <see cref="RouteHandlerBuilder"/> the specified list of status codes as <see cref="ProblemDetails"/> responses.
-        /// </summary>
-        /// <param name="builder">The <see cref="RouteHandlerBuilder"/>.</param>
-        /// <param name="statusCodes">The list of status codes to be added as <see cref="ProblemDetails"/> responses.</param>
-        /// <returns>The <see cref="RouteHandlerBuilder"/> with the new status codes responses.</returns>
-        public RouteHandlerBuilder ProducesDefaultProblem(params int[] statusCodes)
+        foreach (var statusCode in statusCodes)
         {
-            foreach (var statusCode in statusCodes)
-            {
-                builder.ProducesProblem(statusCode);
-            }
-
-            return builder;
+            builder.ProducesProblem(statusCode);
         }
 
+        return builder;
+    }
+
+    extension(RouteHandlerBuilder builder)
+    {
 #if NET10_0_OR_GREATER
         public RouteHandlerBuilder WithResponseDescription(int statusCode, string description)
         {


### PR DESCRIPTION
Refactored ProducesDefaultProblem to be a static extension method for RouteHandlerBuilder, enabling direct usage on builder instances. Updated and relocated XML documentation for improved clarity and IntelliSense support. Removed the old method implementation and its documentation.