### PR TITLE
Add named query filter support for .NET 10+

### DIFF
--- a/TinyHelpers.slnx
+++ b/TinyHelpers.slnx
@@ -13,6 +13,7 @@
   </Folder>
   <Folder Name="/Tests/">
     <Project Path="tests/TinyHelpers.Tests/TinyHelpers.Tests.csproj" />
+    <Project Path="tests/TinyHelpers.EntityFrameworkCore.Tests/TinyHelpers.EntityFrameworkCore.Tests.csproj" />
   </Folder>
   <Project Path="src/TinyHelpers.AspNetCore.Swashbuckle/TinyHelpers.AspNetCore.Swashbuckle.csproj" />
   <Project Path="src/TinyHelpers.AspNetCore/TinyHelpers.AspNetCore.csproj" />

--- a/src/TinyHelpers.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
+++ b/src/TinyHelpers.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
@@ -17,14 +17,11 @@ public static class ModelBuilderExtensions
     /// <param name="expression">The filter expression to apply.</param>
     public static void ApplyQueryFilter<TEntity>(this ModelBuilder modelBuilder, Expression<Func<TEntity, bool>> expression)
     {
-        foreach (var entityType in modelBuilder.Model.GetEntityTypes())
+        foreach (var clrType in modelBuilder.GetEntityTypes<TEntity>())
         {
-            if (typeof(TEntity).IsAssignableFrom(entityType.ClrType))
-            {
-                var parameter = Expression.Parameter(entityType.ClrType);
-                var body = ReplacingExpressionVisitor.Replace(expression.Parameters.Single(), parameter, expression.Body);
-                modelBuilder.Entity(entityType.ClrType).HasQueryFilter(Expression.Lambda(body, parameter));
-            }
+            var parameter = Expression.Parameter(clrType);
+            var body = ReplacingExpressionVisitor.Replace(expression.Parameters.Single(), parameter, expression.Body);
+            modelBuilder.Entity(clrType).HasQueryFilter(Expression.Lambda(body, parameter));
         }
     }
 
@@ -43,7 +40,8 @@ public static class ModelBuilderExtensions
             if (property?.ClrType == typeof(TType))
             {
                 var parameter = Expression.Parameter(entityType.ClrType);
-                var filter = Expression.Lambda(Expression.Equal(Expression.Property(parameter, propertyName), Expression.Constant(value)), parameter);
+                var propertyAccess = Expression.Call(typeof(EF), nameof(EF.Property), [typeof(TType)], parameter, Expression.Constant(propertyName));
+                var filter = Expression.Lambda(Expression.Equal(propertyAccess, Expression.Constant(value, typeof(TType))), parameter);
                 modelBuilder.Entity(entityType.ClrType).HasQueryFilter(filter);
             }
         }
@@ -65,14 +63,11 @@ public static class ModelBuilderExtensions
     /// </remarks>
     public static void ApplyQueryFilter<TEntity>(this ModelBuilder modelBuilder, string filterName, Expression<Func<TEntity, bool>> expression)
     {
-        foreach (var entityType in modelBuilder.Model.GetEntityTypes())
+        foreach (var clrType in modelBuilder.GetEntityTypes<TEntity>())
         {
-            if (typeof(TEntity).IsAssignableFrom(entityType.ClrType))
-            {
-                var parameter = Expression.Parameter(entityType.ClrType);
-                var body = ReplacingExpressionVisitor.Replace(expression.Parameters.Single(), parameter, expression.Body);
-                modelBuilder.Entity(entityType.ClrType).HasQueryFilter(filterName, Expression.Lambda(body, parameter));
-            }
+            var parameter = Expression.Parameter(clrType);
+            var body = ReplacingExpressionVisitor.Replace(expression.Parameters.Single(), parameter, expression.Body);
+            modelBuilder.Entity(clrType).HasQueryFilter(filterName, Expression.Lambda(body, parameter));
         }
     }
 
@@ -98,7 +93,8 @@ public static class ModelBuilderExtensions
             if (property?.ClrType == typeof(TType))
             {
                 var parameter = Expression.Parameter(entityType.ClrType);
-                var filter = Expression.Lambda(Expression.Equal(Expression.Property(parameter, propertyName), Expression.Constant(value)), parameter);
+                var propertyAccess = Expression.Call(typeof(EF), nameof(EF.Property), [typeof(TType)], parameter, Expression.Constant(propertyName));
+                var filter = Expression.Lambda(Expression.Equal(propertyAccess, Expression.Constant(value, typeof(TType))), parameter);
                 modelBuilder.Entity(entityType.ClrType).HasQueryFilter(filterName, filter);
             }
         }
@@ -123,7 +119,7 @@ public static class ModelBuilderExtensions
     public static IEnumerable<Type> GetEntityTypes(this ModelBuilder modelBuilder, Type baseType)
     {
         var entityTypes = modelBuilder.Model.GetEntityTypes()
-            .Where(t => baseType.IsAssignableFrom(t.ClrType))
+            .Where(t => t.ClrType.IsAssignableTo(baseType))
             .ToList();
 
         return entityTypes.Select(t => t.ClrType);

--- a/src/TinyHelpers.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
+++ b/src/TinyHelpers.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
@@ -4,8 +4,17 @@ using Microsoft.EntityFrameworkCore.Query;
 
 namespace TinyHelpers.EntityFrameworkCore.Extensions;
 
+/// <summary>
+/// Provides extension methods for <see cref="ModelBuilder"/> to apply query filters and retrieve entity types.
+/// </summary>
 public static class ModelBuilderExtensions
 {
+    /// <summary>
+    /// Applies a global query filter to all entity types assignable to <typeparamref name="TEntity"/>.
+    /// </summary>
+    /// <typeparam name="TEntity">The base type or interface to match entity types against.</typeparam>
+    /// <param name="modelBuilder">The <see cref="ModelBuilder"/> to apply the filter to.</param>
+    /// <param name="expression">The filter expression to apply.</param>
     public static void ApplyQueryFilter<TEntity>(this ModelBuilder modelBuilder, Expression<Func<TEntity, bool>> expression)
     {
         foreach (var entityType in modelBuilder.Model.GetEntityTypes())
@@ -19,6 +28,13 @@ public static class ModelBuilderExtensions
         }
     }
 
+    /// <summary>
+    /// Applies a global query filter to all entity types that have a property with the specified name and type.
+    /// </summary>
+    /// <typeparam name="TType">The type of the property to filter on.</typeparam>
+    /// <param name="modelBuilder">The <see cref="ModelBuilder"/> to apply the filter to.</param>
+    /// <param name="propertyName">The name of the property to filter on.</param>
+    /// <param name="value">The value to compare the property against.</param>
     public static void ApplyQueryFilter<TType>(this ModelBuilder modelBuilder, string propertyName, TType value)
     {
         foreach (var entityType in modelBuilder.Model.GetEntityTypes())
@@ -33,9 +49,77 @@ public static class ModelBuilderExtensions
         }
     }
 
+#if NET10_0_OR_GREATER
+    /// <summary>
+    /// Applies a named query filter to all entity types assignable to <typeparamref name="TEntity"/>.
+    /// Named query filters can be selectively disabled at query time using <c>IgnoreQueryFilters</c>.
+    /// </summary>
+    /// <typeparam name="TEntity">The base type or interface to match entity types against.</typeparam>
+    /// <param name="modelBuilder">The <see cref="ModelBuilder"/> to apply the filter to.</param>
+    /// <param name="filterName">The name to assign to the query filter.</param>
+    /// <param name="expression">The filter expression to apply.</param>
+    /// <remarks>
+    /// This feature requires .NET 10 or greater. Named query filters allow multiple filters per entity type
+    /// and selective disabling via <c>IgnoreQueryFilters(["filterName"])</c>.
+    /// See <see href="https://learn.microsoft.com/ef/core/querying/filters">EF Core Query Filters</see> for more information.
+    /// </remarks>
+    public static void ApplyQueryFilter<TEntity>(this ModelBuilder modelBuilder, string filterName, Expression<Func<TEntity, bool>> expression)
+    {
+        foreach (var entityType in modelBuilder.Model.GetEntityTypes())
+        {
+            if (typeof(TEntity).IsAssignableFrom(entityType.ClrType))
+            {
+                var parameter = Expression.Parameter(entityType.ClrType);
+                var body = ReplacingExpressionVisitor.Replace(expression.Parameters.Single(), parameter, expression.Body);
+                modelBuilder.Entity(entityType.ClrType).HasQueryFilter(filterName, Expression.Lambda(body, parameter));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Applies a named query filter to all entity types that have a property with the specified name and type.
+    /// Named query filters can be selectively disabled at query time using <c>IgnoreQueryFilters</c>.
+    /// </summary>
+    /// <typeparam name="TType">The type of the property to filter on.</typeparam>
+    /// <param name="modelBuilder">The <see cref="ModelBuilder"/> to apply the filter to.</param>
+    /// <param name="filterName">The name to assign to the query filter.</param>
+    /// <param name="propertyName">The name of the property to filter on.</param>
+    /// <param name="value">The value to compare the property against.</param>
+    /// <remarks>
+    /// This feature requires .NET 10 or greater. Named query filters allow multiple filters per entity type
+    /// and selective disabling via <c>IgnoreQueryFilters(["filterName"])</c>.
+    /// See <see href="https://learn.microsoft.com/ef/core/querying/filters">EF Core Query Filters</see> for more information.
+    /// </remarks>
+    public static void ApplyQueryFilter<TType>(this ModelBuilder modelBuilder, string filterName, string propertyName, TType value)
+    {
+        foreach (var entityType in modelBuilder.Model.GetEntityTypes())
+        {
+            var property = entityType.FindProperty(propertyName);
+            if (property?.ClrType == typeof(TType))
+            {
+                var parameter = Expression.Parameter(entityType.ClrType);
+                var filter = Expression.Lambda(Expression.Equal(Expression.Property(parameter, propertyName), Expression.Constant(value)), parameter);
+                modelBuilder.Entity(entityType.ClrType).HasQueryFilter(filterName, filter);
+            }
+        }
+    }
+#endif
+
+    /// <summary>
+    /// Gets all entity types in the model that are assignable to <typeparamref name="TType"/>.
+    /// </summary>
+    /// <typeparam name="TType">The base type or interface to match entity types against.</typeparam>
+    /// <param name="modelBuilder">The <see cref="ModelBuilder"/> to query.</param>
+    /// <returns>An enumerable of CLR types that are assignable to <typeparamref name="TType"/>.</returns>
     public static IEnumerable<Type> GetEntityTypes<TType>(this ModelBuilder modelBuilder)
         => GetEntityTypes(modelBuilder, typeof(TType));
 
+    /// <summary>
+    /// Gets all entity types in the model that are assignable to the specified <paramref name="baseType"/>.
+    /// </summary>
+    /// <param name="modelBuilder">The <see cref="ModelBuilder"/> to query.</param>
+    /// <param name="baseType">The base type or interface to match entity types against.</param>
+    /// <returns>An enumerable of CLR types that are assignable to <paramref name="baseType"/>.</returns>
     public static IEnumerable<Type> GetEntityTypes(this ModelBuilder modelBuilder, Type baseType)
     {
         var entityTypes = modelBuilder.Model.GetEntityTypes()

--- a/src/TinyHelpers.EntityFrameworkCore/README.md
+++ b/src/TinyHelpers.EntityFrameworkCore/README.md
@@ -82,6 +82,55 @@ protected override void OnModelCreating(ModelBuilder modelBuilder)
 }
 ```
 
+It also works with interfaces:
+
+```csharp
+public interface ISoftDeletable
+{
+    bool IsDeleted { get; set; }
+}
+
+public class Person : ISoftDeletable
+{
+    public int Id { get; set; }
+    public bool IsDeleted { get; set; }
+}
+
+public class City : ISoftDeletable
+{
+    public int Id { get; set; }
+    public bool IsDeleted { get; set; }
+}
+
+// using TinyHelpers.EntityFrameworkCore.Extensions;
+protected override void OnModelCreating(ModelBuilder modelBuilder)
+{
+    // Apply a filter to all the entities that implement ISoftDeletable.
+    modelBuilder.ApplyQueryFilter<ISoftDeletable>(e => !e.IsDeleted);
+}
+```
+
+#### Named Query Filters (.NET 10+)
+
+Starting from .NET 10, the library supports [named query filters](https://learn.microsoft.com/ef/core/querying/filters), which allow attaching names to query filters and managing each one separately. This is useful when you need multiple filters per entity type and want to selectively disable specific filters at query time:
+
+```csharp
+// using TinyHelpers.EntityFrameworkCore.Extensions;
+protected override void OnModelCreating(ModelBuilder modelBuilder)
+{
+    // Apply named filters to all entities that implement the corresponding interfaces.
+    modelBuilder.ApplyQueryFilter<ISoftDeletable>("SoftDelete", e => !e.IsDeleted);
+    modelBuilder.ApplyQueryFilter<ITenantEntity>("TenantFilter", e => e.TenantId == currentTenantId);
+}
+```
+
+Named filters can then be selectively disabled in specific queries:
+
+```csharp
+// Disable only the soft-delete filter, keeping the tenant filter active.
+var allItems = await context.People.IgnoreQueryFilters(["SoftDelete"]).ToListAsync();
+```
+
 ### Contributing
 
 The project is constantly evolving. Contributions are welcome. Feel free to file issues and pull requests on the repo and we'll address them as we can. 

--- a/tests/TinyHelpers.EntityFrameworkCore.Tests/Extensions/ModelBuilderExtensionsTests.cs
+++ b/tests/TinyHelpers.EntityFrameworkCore.Tests/Extensions/ModelBuilderExtensionsTests.cs
@@ -1,0 +1,261 @@
+using Microsoft.EntityFrameworkCore;
+using TinyHelpers.EntityFrameworkCore.Extensions;
+
+namespace TinyHelpers.EntityFrameworkCore.Tests.Extensions;
+
+public interface ISoftDeletable
+{
+    bool IsDeleted { get; set; }
+}
+
+public interface ITenantEntity
+{
+    int TenantId { get; set; }
+}
+
+public abstract class DeletableEntity
+{
+    public bool IsDeleted { get; set; }
+}
+
+public class Person : DeletableEntity, ISoftDeletable, ITenantEntity
+{
+    public int Id { get; set; }
+
+    public string Name { get; set; } = string.Empty;
+
+    public int TenantId { get; set; }
+}
+
+public class City : DeletableEntity, ISoftDeletable
+{
+    public int Id { get; set; }
+
+    public string Name { get; set; } = string.Empty;
+}
+
+public class Country
+{
+    public int Id { get; set; }
+
+    public string Name { get; set; } = string.Empty;
+}
+
+public class ModelBuilderExtensionsTests
+{
+    [Fact]
+    public void ApplyQueryFilter_WithBaseClass_AppliesFilterToInheritingEntities()
+    {
+        var modelBuilder = CreateModelBuilder();
+
+        modelBuilder.ApplyQueryFilter<DeletableEntity>(e => !e.IsDeleted);
+
+        var personFilters = modelBuilder.Model.FindEntityType(typeof(Person))!.GetDeclaredQueryFilters();
+        var cityFilters = modelBuilder.Model.FindEntityType(typeof(City))!.GetDeclaredQueryFilters();
+        var countryFilters = modelBuilder.Model.FindEntityType(typeof(Country))!.GetDeclaredQueryFilters();
+
+        Assert.Single(personFilters);
+        Assert.Single(cityFilters);
+        Assert.Empty(countryFilters);
+    }
+
+    [Fact]
+    public void ApplyQueryFilter_WithInterface_AppliesFilterToImplementingEntities()
+    {
+        var modelBuilder = CreateModelBuilder();
+
+        modelBuilder.ApplyQueryFilter<ISoftDeletable>(e => !e.IsDeleted);
+
+        var personFilters = modelBuilder.Model.FindEntityType(typeof(Person))!.GetDeclaredQueryFilters();
+        var cityFilters = modelBuilder.Model.FindEntityType(typeof(City))!.GetDeclaredQueryFilters();
+        var countryFilters = modelBuilder.Model.FindEntityType(typeof(Country))!.GetDeclaredQueryFilters();
+
+        Assert.Single(personFilters);
+        Assert.Single(cityFilters);
+        Assert.Empty(countryFilters);
+    }
+
+    [Fact]
+    public void ApplyQueryFilter_WithInterface_OnlyAppliesFilterToEntitiesThatImplementInterface()
+    {
+        var modelBuilder = CreateModelBuilder();
+
+        modelBuilder.ApplyQueryFilter<ITenantEntity>(e => e.TenantId == 1);
+
+        var personFilters = modelBuilder.Model.FindEntityType(typeof(Person))!.GetDeclaredQueryFilters();
+        var cityFilters = modelBuilder.Model.FindEntityType(typeof(City))!.GetDeclaredQueryFilters();
+        var countryFilters = modelBuilder.Model.FindEntityType(typeof(Country))!.GetDeclaredQueryFilters();
+
+        Assert.Single(personFilters);
+        Assert.Empty(cityFilters);
+        Assert.Empty(countryFilters);
+    }
+
+    [Fact]
+    public void ApplyQueryFilter_ByPropertyName_AppliesFilterToEntitiesWithMatchingProperty()
+    {
+        var modelBuilder = CreateModelBuilder();
+
+        modelBuilder.ApplyQueryFilter("IsDeleted", false);
+
+        var personFilters = modelBuilder.Model.FindEntityType(typeof(Person))!.GetDeclaredQueryFilters();
+        var cityFilters = modelBuilder.Model.FindEntityType(typeof(City))!.GetDeclaredQueryFilters();
+        var countryFilters = modelBuilder.Model.FindEntityType(typeof(Country))!.GetDeclaredQueryFilters();
+
+        Assert.Single(personFilters);
+        Assert.Single(cityFilters);
+        Assert.Empty(countryFilters);
+    }
+
+    [Fact]
+    public void ApplyNamedQueryFilter_WithBaseClass_AppliesNamedFilterToInheritingEntities()
+    {
+        var modelBuilder = CreateModelBuilder();
+
+        modelBuilder.ApplyQueryFilter<DeletableEntity>("SoftDelete", e => !e.IsDeleted);
+
+        var personFilters = modelBuilder.Model.FindEntityType(typeof(Person))!.GetDeclaredQueryFilters();
+        var cityFilters = modelBuilder.Model.FindEntityType(typeof(City))!.GetDeclaredQueryFilters();
+        var countryFilters = modelBuilder.Model.FindEntityType(typeof(Country))!.GetDeclaredQueryFilters();
+
+        Assert.Single(personFilters);
+        Assert.Single(cityFilters);
+        Assert.Empty(countryFilters);
+    }
+
+    [Fact]
+    public void ApplyNamedQueryFilter_WithInterface_AppliesNamedFilterToImplementingEntities()
+    {
+        var modelBuilder = CreateModelBuilder();
+
+        modelBuilder.ApplyQueryFilter<ISoftDeletable>("SoftDelete", e => !e.IsDeleted);
+
+        var personFilters = modelBuilder.Model.FindEntityType(typeof(Person))!.GetDeclaredQueryFilters();
+        var cityFilters = modelBuilder.Model.FindEntityType(typeof(City))!.GetDeclaredQueryFilters();
+        var countryFilters = modelBuilder.Model.FindEntityType(typeof(Country))!.GetDeclaredQueryFilters();
+
+        Assert.Single(personFilters);
+        Assert.Single(cityFilters);
+        Assert.Empty(countryFilters);
+    }
+
+    [Fact]
+    public void ApplyNamedQueryFilter_WithInterface_OnlyAppliesFilterToEntitiesThatImplementInterface()
+    {
+        var modelBuilder = CreateModelBuilder();
+
+        modelBuilder.ApplyQueryFilter<ITenantEntity>("TenantFilter", e => e.TenantId == 1);
+
+        var personFilters = modelBuilder.Model.FindEntityType(typeof(Person))!.GetDeclaredQueryFilters();
+        var cityFilters = modelBuilder.Model.FindEntityType(typeof(City))!.GetDeclaredQueryFilters();
+        var countryFilters = modelBuilder.Model.FindEntityType(typeof(Country))!.GetDeclaredQueryFilters();
+
+        Assert.Single(personFilters);
+        Assert.Empty(cityFilters);
+        Assert.Empty(countryFilters);
+    }
+
+    [Fact]
+    public void ApplyNamedQueryFilter_MultipleFilters_AllFiltersAreApplied()
+    {
+        var modelBuilder = CreateModelBuilder();
+
+        modelBuilder.ApplyQueryFilter<ISoftDeletable>("SoftDelete", e => !e.IsDeleted);
+        modelBuilder.ApplyQueryFilter<ITenantEntity>("TenantFilter", e => e.TenantId == 1);
+
+        var personFilters = modelBuilder.Model.FindEntityType(typeof(Person))!.GetDeclaredQueryFilters();
+        var cityFilters = modelBuilder.Model.FindEntityType(typeof(City))!.GetDeclaredQueryFilters();
+        var countryFilters = modelBuilder.Model.FindEntityType(typeof(Country))!.GetDeclaredQueryFilters();
+
+        Assert.Equal(2, personFilters.Count);
+        Assert.Single(cityFilters);
+        Assert.Empty(countryFilters);
+    }
+
+    [Fact]
+    public void ApplyNamedQueryFilter_ByPropertyName_AppliesNamedFilterToEntitiesWithMatchingProperty()
+    {
+        var modelBuilder = CreateModelBuilder();
+
+        modelBuilder.ApplyQueryFilter("SoftDelete", "IsDeleted", false);
+
+        var personFilters = modelBuilder.Model.FindEntityType(typeof(Person))!.GetDeclaredQueryFilters();
+        var cityFilters = modelBuilder.Model.FindEntityType(typeof(City))!.GetDeclaredQueryFilters();
+        var countryFilters = modelBuilder.Model.FindEntityType(typeof(Country))!.GetDeclaredQueryFilters();
+
+        Assert.Single(personFilters);
+        Assert.Single(cityFilters);
+        Assert.Empty(countryFilters);
+    }
+
+    [Fact]
+    public void ApplyNamedQueryFilter_FindByName_ReturnsCorrectFilter()
+    {
+        var modelBuilder = CreateModelBuilder();
+
+        modelBuilder.ApplyQueryFilter<ISoftDeletable>("SoftDelete", e => !e.IsDeleted);
+        modelBuilder.ApplyQueryFilter<ITenantEntity>("TenantFilter", e => e.TenantId == 1);
+
+        var personType = modelBuilder.Model.FindEntityType(typeof(Person))!;
+
+        var softDeleteFilter = personType.FindDeclaredQueryFilter("SoftDelete");
+        var tenantFilter = personType.FindDeclaredQueryFilter("TenantFilter");
+        var nonExistentFilter = personType.FindDeclaredQueryFilter("NonExistent");
+
+        Assert.NotNull(softDeleteFilter);
+        Assert.NotNull(tenantFilter);
+        Assert.Null(nonExistentFilter);
+    }
+
+    [Fact]
+    public void GetEntityTypes_WithBaseClass_ReturnsInheritingTypes()
+    {
+        var modelBuilder = CreateModelBuilder();
+
+        var types = modelBuilder.GetEntityTypes<DeletableEntity>().ToList();
+
+        Assert.Contains(typeof(Person), types);
+        Assert.Contains(typeof(City), types);
+        Assert.DoesNotContain(typeof(Country), types);
+    }
+
+    [Fact]
+    public void GetEntityTypes_WithInterface_ReturnsImplementingTypes()
+    {
+        var modelBuilder = CreateModelBuilder();
+
+        var types = modelBuilder.GetEntityTypes<ISoftDeletable>().ToList();
+
+        Assert.Contains(typeof(Person), types);
+        Assert.Contains(typeof(City), types);
+        Assert.DoesNotContain(typeof(Country), types);
+    }
+
+    private static ModelBuilder CreateModelBuilder()
+    {
+        var modelBuilder = new ModelBuilder();
+
+        modelBuilder.Entity<Person>(b =>
+        {
+            b.Property(p => p.Id);
+            b.Property(p => p.Name);
+            b.Property(p => p.IsDeleted);
+            b.Property(p => p.TenantId);
+        });
+
+        modelBuilder.Entity<City>(b =>
+        {
+            b.Property(c => c.Id);
+            b.Property(c => c.Name);
+            b.Property(c => c.IsDeleted);
+        });
+
+        modelBuilder.Entity<Country>(b =>
+        {
+            b.Property(c => c.Id);
+            b.Property(c => c.Name);
+        });
+
+        return modelBuilder;
+    }
+}

--- a/tests/TinyHelpers.EntityFrameworkCore.Tests/TinyHelpers.EntityFrameworkCore.Tests.csproj
+++ b/tests/TinyHelpers.EntityFrameworkCore.Tests/TinyHelpers.EntityFrameworkCore.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\TinyHelpers.EntityFrameworkCore\TinyHelpers.EntityFrameworkCore.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/TinyHelpers.EntityFrameworkCore.Tests/Usings.cs
+++ b/tests/TinyHelpers.EntityFrameworkCore.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;


### PR DESCRIPTION
This pull request introduces significant enhancements to the `TinyHelpers.EntityFrameworkCore` library, focusing on expanding query filter capabilities and adding comprehensive test coverage. The most important changes are grouped below by theme.

### Query Filter Enhancements

* Added support for applying query filters based on base classes, interfaces, and property names, allowing filters to be applied more flexibly across entity types in `ModelBuilderExtensions`.
* Introduced support for named query filters (for .NET 10+), enabling multiple filters per entity type and selective disabling of filters at query time.
* Improved documentation in `README.md` to demonstrate usage with interfaces and named query filters, including practical code examples.

### Testing Improvements

* Added a new test project `TinyHelpers.EntityFrameworkCore.Tests` with extensive unit tests covering all query filter scenarios, including base class, interface, property name, and named filters. [[1]](diffhunk://#diff-76d82642d8ee8bcf9c83b60d2a6ae6dfc44afc59d3d6ddbd73147cd5d9d5e108R1-R261) [[2]](diffhunk://#diff-775324adfb819ea234bdbcb292f939d8a7468d63190e65bda1c6bb7c084c39edR1-R27)
* Registered the new test project in the solution file `TinyHelpers.slnx` for better visibility and integration.
* Added global using for `Xunit` in the test project to simplify test code.

Closes #288 