### PR TITLE
Update NuGet package versions in project files

### DIFF
--- a/samples/TinyHelpers.AspNetCore.Sample/TinyHelpers.AspNetCore.Sample.csproj
+++ b/samples/TinyHelpers.AspNetCore.Sample/TinyHelpers.AspNetCore.Sample.csproj
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.4" />
-        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.5" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.6" />
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.7" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/TinyHelpers.AspNetCore8.Sample/TinyHelpers.AspNetCore8.Sample.csproj
+++ b/samples/TinyHelpers.AspNetCore8.Sample/TinyHelpers.AspNetCore8.Sample.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.5" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/TinyHelpers.AspNetCore/TinyHelpers.AspNetCore.csproj
+++ b/src/TinyHelpers.AspNetCore/TinyHelpers.AspNetCore.csproj
@@ -25,11 +25,11 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.14" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.15" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.4" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.6" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/TinyHelpers/TinyHelpers.csproj
+++ b/src/TinyHelpers/TinyHelpers.csproj
@@ -30,7 +30,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Json" Version="10.0.4" />
+        <PackageReference Include="System.Text.Json" Version="10.0.6" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Upgraded Microsoft.AspNetCore.OpenApi, Swashbuckle.AspNetCore, Swashbuckle.AspNetCore.SwaggerUI, and System.Text.Json to their latest patch versions across sample and core project files for improved compatibility and security.