### PR TITLE
Update dependencies and enhance OpenAPI schema handling

### DIFF
--- a/samples/TinyHelpers.AspNetCore.Sample/Program.cs
+++ b/samples/TinyHelpers.AspNetCore.Sample/Program.cs
@@ -60,7 +60,7 @@ builder.Services.AddOpenApi(options =>
     // Remove Servers list in OpenAPI.
     options.RemoveServerList();
 
-    // Respect the ignored JsonNumberHandling attribute.
+    // Respect the JsonNumberHandling attribute.
     options.WriteNumberAsString();
 
     // Describe all query string parameters in Camel Case.
@@ -72,6 +72,9 @@ builder.Services.AddOpenApi(options =>
     // Uncomment to use full type names (including namespace) for schema IDs.
     // This helps avoid naming collisions when multiple types have the same name.
     // options.UseFullTypeNameSchemaIds();
+
+    // Remove the string fallback from numeric schemas generated for OpenAPI.
+    options.UseStrictNumericSchemas();
 });
 
 // Add default problem details and exception handler.
@@ -102,7 +105,7 @@ app.MapGet("/api/language", () =>
     return TypedResults.Ok(new { Language = language });
 }).WithResponseDescription(StatusCodes.Status200OK, "The language of the server");
 
-app.MapGet("/api/json-number-as-string", () =>
+app.MapGet("/api/json-number-as-string", (int a) =>
 {
     return TypedResults.Ok(new RandomNumber());
 });

--- a/samples/TinyHelpers.AspNetCore.Sample/TinyHelpers.AspNetCore.Sample.csproj
+++ b/samples/TinyHelpers.AspNetCore.Sample/TinyHelpers.AspNetCore.Sample.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.6" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
         <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.7" />
     </ItemGroup>
 

--- a/samples/TinyHelpers.Dapper.Sample/TinyHelpers.Dapper.Sample.csproj
+++ b/samples/TinyHelpers.Dapper.Sample/TinyHelpers.Dapper.Sample.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/TinyHelpers.EntityFrameworkCore.Sample/TinyHelpers.EntityFrameworkCore.Sample.csproj
+++ b/samples/TinyHelpers.EntityFrameworkCore.Sample/TinyHelpers.EntityFrameworkCore.Sample.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.4" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/TinyHelpers.AspNetCore/OpenApi/OpenApiExtensions.cs
+++ b/src/TinyHelpers.AspNetCore/OpenApi/OpenApiExtensions.cs
@@ -1,10 +1,7 @@
 ﻿#if NET9_0_OR_GREATER
 
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.OpenApi;
 using TinyHelpers.AspNetCore.OpenApi.Transformers;
 
 namespace TinyHelpers.AspNetCore.OpenApi;
@@ -98,6 +95,11 @@ public static class OpenApiExtensions
 
             return options;
         }
+
+#if NET10_0_OR_GREATER
+        public OpenApiOptions UseStrictNumericSchemas()
+            => options.AddSchemaTransformer<StrictNumericSchemaTransformer>();
+#endif
     }
 }
 

--- a/src/TinyHelpers.AspNetCore/OpenApi/OpenApiExtensions.cs
+++ b/src/TinyHelpers.AspNetCore/OpenApi/OpenApiExtensions.cs
@@ -76,13 +76,24 @@ public static class OpenApiExtensions
         {
             ArgumentNullException.ThrowIfNull(options);
 
-            options.CreateSchemaReferenceId = (jsonTypeInfo) =>
+            options.CreateSchemaReferenceId = jsonTypeInfo =>
             {
-                // Get the full type name (including namespace) for the schema ID
-                var fullName = jsonTypeInfo.Type.FullName;
+                // Create the default ID (handles generics, nested types, etc.)
+                var defaultId = OpenApiOptions.CreateDefaultSchemaReferenceId(jsonTypeInfo);
+                if (string.IsNullOrEmpty(defaultId))
+                {
+                    return defaultId;
+                }
 
-                // Replace + with . for nested types to make the schema ID more readable
-                return fullName?.Replace('+', '.');
+                var @namespace = jsonTypeInfo.Type.Namespace;
+                if (string.IsNullOrEmpty(@namespace))
+                {
+                    // If there's no namespace, just keep the default.
+                    return defaultId;
+                }
+
+                // Include namespace in the reference ID.
+                return $"{@namespace}.{defaultId}";
             };
 
             return options;

--- a/src/TinyHelpers.AspNetCore/OpenApi/Transformers/StrictNumericSchemaTransformer.cs
+++ b/src/TinyHelpers.AspNetCore/OpenApi/Transformers/StrictNumericSchemaTransformer.cs
@@ -1,0 +1,31 @@
+﻿#if NET10_0_OR_GREATER
+
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi;
+
+namespace TinyHelpers.AspNetCore.OpenApi.Transformers;
+
+internal sealed class StrictNumericSchemaTransformer : IOpenApiSchemaTransformer
+{
+    public Task TransformAsync(OpenApiSchema schema, OpenApiSchemaTransformerContext context, CancellationToken cancellationToken)
+    {
+        if (schema.Type is null)
+        {
+            return Task.CompletedTask;
+        }
+
+        var type = schema.Type.Value;
+        var hasNumeric = type.HasFlag(JsonSchemaType.Integer) || type.HasFlag(JsonSchemaType.Number);
+        var hasString = type.HasFlag(JsonSchemaType.String);
+
+        if (hasNumeric && hasString)
+        {
+            schema.Type &= ~JsonSchemaType.String;
+            schema.Pattern = null;
+        }
+
+        return Task.CompletedTask;
+    }
+}
+
+#endif

--- a/src/TinyHelpers.AspNetCore/TinyHelpers.AspNetCore.csproj
+++ b/src/TinyHelpers.AspNetCore/TinyHelpers.AspNetCore.csproj
@@ -25,11 +25,11 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.15" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.6" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/TinyHelpers.AspNetCore/version.json
+++ b/src/TinyHelpers.AspNetCore/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "4.1",
+    "version": "4.2",
     "publicReleaseRefSpec": [
         "^refs/heads/master$" // we release out of master
     ],

--- a/src/TinyHelpers/TinyHelpers.csproj
+++ b/src/TinyHelpers/TinyHelpers.csproj
@@ -30,7 +30,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Json" Version="10.0.6" />
+        <PackageReference Include="System.Text.Json" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/TinyHelpers.EntityFrameworkCore.Tests/TinyHelpers.EntityFrameworkCore.Tests.csproj
+++ b/tests/TinyHelpers.EntityFrameworkCore.Tests/TinyHelpers.EntityFrameworkCore.Tests.csproj
@@ -8,12 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/TinyHelpers.Tests/TinyHelpers.Tests.csproj
+++ b/tests/TinyHelpers.Tests/TinyHelpers.Tests.csproj
@@ -8,12 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
This pull request introduces improvements to OpenAPI schema generation in the `TinyHelpers.AspNetCore` library, particularly around numeric schema strictness and schema ID generation. It also updates several package dependencies across the solution and increments the package version.

**OpenAPI enhancements:**

* Added a new `UseStrictNumericSchemas` extension method and `StrictNumericSchemaTransformer` to remove the string fallback from numeric schemas in OpenAPI for .NET 10.0 or greater, ensuring stricter type representation. [[1]](diffhunk://#diff-956de216ef27214a9838f373c662d24eacb6d02b854bd09090c07a866f6c1462R1-R31) [[2]](diffhunk://#diff-3fb0a3c16ab2e79f5927e9d359c8ce1eee977ddf5094cf176e408f9fdffb3a3fL79-R102) [[3]](diffhunk://#diff-df7fae3008b0994995749092b1d506f28cf6a598dc0f01a497007b17e978e3d1R75-R77)
* Improved the `UseFullTypeNameSchemaIds` method to generate more robust schema IDs by including namespaces and handling generics/nested types, reducing naming collisions.

**Sample and API usage updates:**

* Updated the OpenAPI sample to use the new strict numeric schema option and clarified usage of JSON number handling in the sample API. [[1]](diffhunk://#diff-df7fae3008b0994995749092b1d506f28cf6a598dc0f01a497007b17e978e3d1L63-R63) [[2]](diffhunk://#diff-df7fae3008b0994995749092b1d506f28cf6a598dc0f01a497007b17e978e3d1R75-R77) [[3]](diffhunk://#diff-df7fae3008b0994995749092b1d506f28cf6a598dc0f01a497007b17e978e3d1L105-R108)

**Dependency updates:**

* Updated `Microsoft.AspNetCore.OpenApi`, `System.Text.Json`, `Microsoft.EntityFrameworkCore.SqlServer`, `Microsoft.Data.SqlClient`, and other related package references to their latest patch versions across multiple projects, improving compatibility and security. [[1]](diffhunk://#diff-fafa5a3c0fb49cb769dc1af1ae17ed170e4bf7f5d243c8fdea17e65194366b2cL10-R10) [[2]](diffhunk://#diff-4520577c4a78d90bbcf90409330925b0932cfd6fd5ba93887a0f4311ad3857d3L9-R9) [[3]](diffhunk://#diff-24a284e03ab31ffea58036e6583503db3061594136bcd8f05f336ed36b1b89d7L10-R10) [[4]](diffhunk://#diff-d26f447cff81c03de4ef7faa4dda0316e1f1bfdc226805957ad23536a3ce45efL33-R33) [[5]](diffhunk://#diff-b13990ce44fceb8c74508ecfe9842430f57546ced0cf0dae42e1e81b9189988dL28-R32)
* Updated test project dependencies, including `Microsoft.NET.Test.Sdk` and `coverlet.collector`, to the latest versions. [[1]](diffhunk://#diff-775324adfb819ea234bdbcb292f939d8a7468d63190e65bda1c6bb7c084c39edL11-R16) [[2]](diffhunk://#diff-34c746de445cb56861ec93b6a630eab29a5f4337e241275c7a98252d74f11c6bL11-R16)

**Versioning:**

* Bumped the library version from 4.1 to 4.2 in `version.json`.