### PR TITLE
Update docs for OpenAPI parameter registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ dotnet add package TinyHelpers
 
 Or search for `TinyHelpers` in the Visual Studio Package Manager.
 
+## Other package documentation
+
+Additional documentation is available for these packages:
+
+- [TinyHelpers.AspNetCore](src/TinyHelpers.AspNetCore/README.md)
+- [TinyHelpers.AspNetCore.Swashbuckle](src/TinyHelpers.AspNetCore.Swashbuckle/README.md)
+- [TinyHelpers.EntityFrameworkCore](src/TinyHelpers.EntityFrameworkCore/README.md)
+- [TinyHelpers.Dapper](src/TinyHelpers.Dapper/README.md)
+
 ## Contents
 
 - [Collections and sequences](#collections-and-sequences)

--- a/src/TinyHelpers.AspNetCore.Swashbuckle/SwaggerExtensions.cs
+++ b/src/TinyHelpers.AspNetCore.Swashbuckle/SwaggerExtensions.cs
@@ -49,22 +49,20 @@ public static class SwaggerExtensions
         }
 
         /// <summary>
-        /// Adds a shared parameter definition pipeline to Swagger generation.
+        /// Adds shared OpenAPI parameter definitions so they are automatically applied to every generated operation.
         /// </summary>
+        /// <seealso cref="AddSwaggerOperationParameters(IServiceCollection, Action{OpenApiOperationOptions})"/>
         public void AddOperationParameters()
             => options.OperationFilter<OpenApiParametersOperationFilter>();
     }
 
     /// <summary>
-    /// Registers a reusable set of OpenAPI parameters in the dependency injection container.
+    /// Registers OpenAPI parameter definitions that can be automatically applied to every operation.
     /// </summary>
-    /// <remarks>
-    /// This lets applications define shared parameters once and then reuse them during Swagger
-    /// generation through <see cref="OpenApiParametersOperationFilter" />.
-    /// </remarks>
     /// <param name="services">The service collection to extend.</param>
     /// <param name="setupAction">The configuration callback used to populate shared parameters.</param>
     /// <returns>The same <see cref="IServiceCollection" /> instance so calls can be chained.</returns>
+    /// <seealso cref="AddOperationParameters(SwaggerGenOptions)"/>
     public static IServiceCollection AddSwaggerOperationParameters(this IServiceCollection services, Action<OpenApiOperationOptions> setupAction)
     {
         ArgumentNullException.ThrowIfNull(services);

--- a/src/TinyHelpers.AspNetCore/OpenApi/OpenApiExtensions.cs
+++ b/src/TinyHelpers.AspNetCore/OpenApi/OpenApiExtensions.cs
@@ -14,10 +14,11 @@ public static class OpenApiExtensions
     extension(IServiceCollection services)
     {
         /// <summary>
-        /// Captures endpoint parameter metadata once and reuses it during OpenAPI generation so the application can keep custom parameter rules in a single place.
+        /// Registers OpenAPI parameter definitions that can be automatically applied to every operation.
         /// </summary>
         /// <param name="setupAction">A callback that fills the parameter options object.</param>
         /// <returns>The same <see cref="IServiceCollection" /> for fluent registration.</returns>
+        /// <seealso cref="AddOperationParameters(OpenApiOptions)"/>
         public IServiceCollection AddOpenApiOperationParameters(Action<OpenApiOperationOptions> setupAction)
         {
             ArgumentNullException.ThrowIfNull(services);
@@ -56,9 +57,10 @@ public static class OpenApiExtensions
         }
 
         /// <summary>
-        /// Adds custom query-parameter metadata rules when the default generated names are not sufficient.
+        /// Adds shared OpenAPI parameter definitions so they are automatically applied to every generated operation.
         /// </summary>
         /// <returns>The same <see cref="OpenApiOptions" /> for fluent configuration.</returns>
+        /// <seealso cref="AddOpenApiOperationParameters(IServiceCollection, Action{OpenApiOperationOptions})"/>
         public OpenApiOptions AddOperationParameters()
             => options.AddOperationTransformer<OpenApiParametersOperationFilter>();
 


### PR DESCRIPTION
Expanded and clarified XML docs for OpenAPI/Swagger parameter methods, added <seealso> tags, and improved summaries. Added links to related package documentation in README.md.