### PR TITLE
Enhance XML documentation and README for public APIs and usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -351,3 +351,4 @@ MigrationBackup/
 
 /src/TinyHelpers/TinyHelpers.xml
 /src/TinyHelpers.AspNetCore/TinyHelpers.AspNetCore.xml
+/src/TinyHelpers.AspNetCore.Swashbuckle/TinyHelpers.AspNetCore.Swashbuckle.xml

--- a/.gitignore
+++ b/.gitignore
@@ -350,3 +350,4 @@ MigrationBackup/
 .ionide/
 
 /src/TinyHelpers/TinyHelpers.xml
+/src/TinyHelpers.AspNetCore/TinyHelpers.AspNetCore.xml

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![NuGet](https://img.shields.io/nuget/dt/TinyHelpers)](https://www.nuget.org/packages/TinyHelpers)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/marcominerva/TinyHelpers/blob/master/LICENSE)
 
-TinyHelpers is a small .NET utility library that groups common helpers into a single package. It is designed to reduce repeated boilerplate in application code while keeping each helper focused and easy to discover.
+TinyHelpers is a small .NET utility library that groups common helpers into a single package. It is designed to reduce repeated boilerplate in application code while keeping each helper focused, discoverable, and explicit about the contract it supports.
 
 ## Compatibility
 
@@ -48,20 +48,21 @@ Additional documentation is available for these packages:
 - [HTTP helpers](#http-helpers)
 - [JSON serialization](#json-serialization)
 - [Threading](#threading)
-- [Compatibility helpers](#compatibility-helpers)
 - [Quick examples](#quick-examples)
 
 ## Collections and sequences
+
+The collection helpers keep common null-safety, indexing, asynchronous projection, and conditional filtering patterns reusable. They are intended for code that repeatedly composes LINQ queries or optional collections and should avoid scattering small guard clauses across the codebase.
 
 ### `CollectionExtensions`
 
 | Method | What it does | When to use it |
 | --- | --- | --- |
 | `EmptyIfNull()` | Returns an empty sequence when the source is `null`. | When you want to avoid null checks before enumeration. |
-| `ForEach(Action<T>)` | Executes an action for each item in a sequence. | When you want a simple side-effect loop. |
-| `ForEachAsync(Func<T, Task>)` | Executes an asynchronous action for each item. | When each item requires asynchronous work. |
-| `SelectAsync(Func<T, Task<TResult>>)` | Projects each item asynchronously. | When the projection itself is asynchronous. |
-| `ToListAsync()` | Materializes an asynchronous sequence into a list. | When you need a list from an async source. |
+| `ForEach(Action<T>)` | Executes an action for each item and returns the original sequence. | When a side-effect step should remain in a fluent pipeline. |
+| `ForEachAsync(Func<T, Task>)` | Executes an asynchronous action for each item and returns the original sequence after all actions complete. | When each item requires asynchronous work but the original values are still needed. |
+| `SelectAsync(Func<T, Task<TResult>>)` | Projects each item asynchronously while preserving source order in the materialized result. | When the projection itself is asynchronous. |
+| `ToListAsync()` | Materializes an asynchronous sequence into an in-memory sequence. | When later code needs synchronous enumeration from an async source. |
 | `Remove(predicate)` | Removes matching items from a collection. | When you want to filter in place. |
 | `IsEmpty()` / `IsNotEmpty()` | Checks whether a collection contains items. | When you want readable emptiness checks. |
 | `IsNullOrEmpty()` / `IsNotNullOrEmpty()` | Checks for `null` or empty sequences. | When the source may be missing entirely. |
@@ -149,8 +150,8 @@ var insideRange = 5.IsBetween(1, 10);
 
 | Method | What it does |
 | --- | --- |
-| `ToDateOnly()` | Converts a `DateTimeOffset` to `DateOnly`. |
-| `ToTimeOnly()` | Converts a `DateTimeOffset` to `TimeOnly`. |
+| `ToDateOnly(TimeZoneInfo? zone = null)` | Converts a `DateTimeOffset` to `DateOnly` after applying the specified time zone, or UTC when no zone is provided. |
+| `ToTimeOnly(TimeZoneInfo? zone = null)` | Converts a `DateTimeOffset` to `TimeOnly` after applying the specified time zone, or UTC when no zone is provided. |
 
 ### `DateOnlyExtensions`
 
@@ -195,7 +196,7 @@ var timeOnly = createdAt.ToTimeOnly();
 | `IsEmpty()` | Checks whether a GUID is `Guid.Empty`. | When validating identifiers. |
 | `IsNotEmpty()` | Checks whether a GUID is not empty. | When you need a positive validation. |
 | `HasValue()` | Checks whether a GUID is different from `null` and `Guid.Empty`. | When handling optional identifiers. |
-| `GetValueOrCreateNew()` | Returns the existing GUID when it is different from `null` and `Guid.Empty`; otherwise, it creates a new one automatically. On .NET 9+, you can also specify the GUID version to generate. | When you want to assign an identifier lazily. |
+| `GetValueOrCreateNew()` | Returns the existing GUID when it is different from `null` and `Guid.Empty`; otherwise, it creates a new one automatically. On .NET 9+, you can also specify the GUID version to generate. | When you want to assign an identifier lazily at application boundaries, persistence boundaries, or outbound messages. |
 | `GetValueOrDefault()` | Returns the current GUID when it is different from `Guid.Empty`; otherwise, it returns a default value. | When null-safe defaults are useful. |
 
 ### Example
@@ -215,7 +216,7 @@ var defaultId = id.GetValueOrDefault();
 
 Adds an access token to outgoing requests through a delegate that can inspect the current `HttpRequestMessage`. If a request returns `401 Unauthorized` and a refresh delegate is configured, the handler can refresh the token and retry the request once. The authorization scheme is configurable and defaults to `Bearer`.
 
-Use this handler when the token depends on the outgoing request or when you need a lightweight refresh flow around a protected API.
+Use this handler when token acquisition depends on the outgoing request, such as per-tenant or per-resource tokens, or when you need a lightweight refresh flow around a protected API.
 
 ### Example
 
@@ -232,7 +233,7 @@ var client = new HttpClient(handler);
 
 Adds headers to outgoing requests by invoking a delegate that returns a dictionary of header names and values. Each returned header is applied with `TryAddWithoutValidation`, so the handler is suitable for custom or preformatted header values.
 
-Use this handler when headers such as correlation IDs, tenant identifiers, or custom API metadata need to be injected per request.
+Use this handler when headers such as correlation IDs, tenant identifiers, or custom API metadata need to be injected per request without repeating header setup at every call site.
 
 ### Example
 
@@ -251,7 +252,7 @@ var client = new HttpClient(handler);
 
 Adds query string parameters to outgoing requests by merging the values returned by a delegate into the current request URI. Existing query string values are preserved, and new values are appended to the request URL.
 
-Use this handler when the query string depends on the current request context and you want to centralize URL composition.
+Use this handler when the query string depends on the current request context and you want to centralize URL composition for pagination, tenant selection, feature flags, or similar cross-cutting values.
 
 ### Example
 
@@ -273,19 +274,19 @@ var client = new HttpClient(handler)
 
 ### `ShortDateConverter`
 
-Serializes a `DateTime` using only the date portion.
+Serializes and deserializes a `DateTime` using only the date portion when time-of-day information is not part of the JSON contract.
 
 ### `UtcDateTimeConverter`
 
-Serializes and deserializes `DateTime` values in UTC format.
+Serializes and deserializes `DateTime` values in UTC format so the JSON boundary normalizes date-time values instead of preserving local offsets or unspecified kinds.
 
 ### `TimeSpanTicksConverter`
 
-Serializes a `TimeSpan` as ticks.
+Serializes and deserializes a `TimeSpan` as ticks so durations round-trip without string-format ambiguity.
 
 ### `StringTrimmingConverter`
 
-Trims whitespace from JSON strings during read and write operations.
+Trims leading and trailing whitespace from JSON strings during read and write operations when the JSON boundary should normalize user-entered text.
 
 ### `StringEnumMemberConverter`
 

--- a/src/TinyHelpers.AspNetCore.Swashbuckle/Filters/OpenApiOperationOptions.cs
+++ b/src/TinyHelpers.AspNetCore.Swashbuckle/Filters/OpenApiOperationOptions.cs
@@ -3,12 +3,12 @@
 namespace TinyHelpers.AspNetCore.Swagger.Filters;
 
 /// <summary>
-/// Describes additional OpenAPI parameters that should be attached to every operation.
+/// Collects reusable Swagger operation metadata that should be applied consistently across multiple endpoints.
 /// </summary>
 /// <remarks>
-/// Instances are created through dependency injection and consumed by
-/// <see cref="OpenApiParametersOperationFilter" /> to avoid duplicating parameter definitions in
-/// multiple Swagger configuration points.
+/// The library uses this options object to register shared parameter definitions once and copy them into the
+/// generated OpenAPI document wherever they are needed. This keeps endpoint setup centralized and avoids drift between
+/// route metadata and the generated client contract.
 /// </remarks>
 public class OpenApiOperationOptions
 {
@@ -20,7 +20,11 @@ public class OpenApiOperationOptions
     }
 
     /// <summary>
-    /// Gets the parameters that should be appended to generated OpenAPI operations.
+    /// Gets the parameter definitions that should be merged into generated Swagger operations.
     /// </summary>
+    /// <remarks>
+    /// Parameters are intentionally stored here rather than declared inline on each route so callers can reuse metadata
+    /// for cross-cutting inputs such as headers or query values while keeping the generated contract consistent.
+    /// </remarks>
     public IList<OpenApiParameter> Parameters { get; } = [];
 }

--- a/src/TinyHelpers.AspNetCore.Swashbuckle/README.md
+++ b/src/TinyHelpers.AspNetCore.Swashbuckle/README.md
@@ -8,7 +8,7 @@
 
 TinyHelpers.AspNetCore.Swashbuckle is a small collection of practical helpers for Swashbuckle ASP.NET Core applications.
 It keeps common Swagger configuration in one place so applications can reuse the same OpenAPI conventions without
-duplicating setup code across startup files.
+duplicating setup code across startup files, endpoint metadata, or custom filters.
 
 ## Compatibility
 
@@ -43,26 +43,18 @@ Or search for `TinyHelpers.AspNetCore.Swashbuckle` in the Visual Studio Package 
 
 | Method | What it does | When to use it |
 | --- | --- | --- |
-| `AddAcceptLanguageHeader()` | Adds the `Accept-Language` header to documented operations when the app has supported cultures. | When your API uses request localization and you want consumers to discover the supported culture values. |
-| `AddDefaultProblemDetailsResponse()` | Adds a default `application/problem+json` response to operations. | When you want a consistent error contract in Swagger UI and generated documents. |
-| `AddTimeSpanTypeMapping(bool useCurrentTimeAsExample = false)` | Maps `TimeSpan` to a string schema and optionally adds a readable example. | When your API exposes `TimeSpan` values and you want a clearer schema. |
+| `AddAcceptLanguageHeader()` | Adds the `Accept-Language` header to documented operations when the app has supported cultures. | When your API uses request localization and consumers need to discover supported culture values. |
+| `AddDefaultProblemDetailsResponse()` | Adds a default `application/problem+json` response to generated operations. | When you want a consistent error contract in Swagger UI and generated documents. |
+| `AddTimeSpanTypeMapping(bool useCurrentTimeAsExample = false)` | Maps `TimeSpan` to a string schema and optionally adds a readable example. | When your API exposes `TimeSpan` values and you want the schema to show the wire format clearly. |
 | `AddTimeSpanTypeMapping(string? example)` | Maps `TimeSpan` to a string schema using a custom example value. | When you want a precise sample that matches your API format. |
-| `AddSwaggerOperationParameters(Action<OpenApiOperationOptions> setupAction)` | Registers reusable OpenAPI parameters in the dependency injection container. | When you want to define shared parameters once and reuse them in Swagger generation. |
-| `AddOperationParameters()` | Adds the parameters configured through `OpenApiOperationOptions`. | When you want the shared parameters to appear in the generated Swagger operations. |
+| `AddSwaggerOperationParameters(Action<OpenApiOperationOptions> setupAction)` | Registers reusable Swagger operation parameters in the dependency injection container. | When cross-cutting headers or query values must be declared once and reused during Swagger generation. |
+| `AddOperationParameters()` | Adds the operation filter that copies registered shared parameters into generated Swagger operations. | When you want the generated contract to include the parameters registered with `AddSwaggerOperationParameters()`. |
 
 ### Example
 
 ```csharp
 using Microsoft.OpenApi;
 using TinyHelpers.AspNetCore.Swagger;
-
-builder.Services.AddSwaggerGen(options =>
-{
-    options.AddAcceptLanguageHeader();
-    options.AddDefaultProblemDetailsResponse();
-    options.AddTimeSpanTypeMapping(useCurrentTimeAsExample: true);
-    options.AddOperationParameters();
-});
 
 builder.Services.AddSwaggerOperationParameters(parameters =>
 {
@@ -74,22 +66,35 @@ builder.Services.AddSwaggerOperationParameters(parameters =>
         Description = "Identifier used to correlate requests"
     });
 });
+
+builder.Services.AddSwaggerGen(options =>
+{
+    options.AddAcceptLanguageHeader();
+    options.AddDefaultProblemDetailsResponse();
+    options.AddTimeSpanTypeMapping(useCurrentTimeAsExample: true);
+    options.AddOperationParameters();
+});
 ```
+
+Register shared parameters with `AddSwaggerOperationParameters()` during service registration, then enable
+`AddOperationParameters()` in `AddSwaggerGen(...)`. The options object stores the shared parameter definitions, and the
+operation filter copies them into generated operations. This prevents duplicated endpoint metadata while preserving a
+complete contract for Swagger UI and generated clients.
 
 ## Schema helpers
 
 ### `OpenApiSchemaHelper`
 
 This helper provides ready-to-use schema fragments that can be reused when building custom Swagger filters or other
-OpenAPI customizations.
+OpenAPI customizations. It keeps default values, formats, and enum choices consistent across generated documents.
 
 | Method | What it does | When to use it |
 | --- | --- | --- |
-| `CreateStringSchema(string? defaultValue = null)` | Creates a string schema with an optional default value. | When you want a simple reusable string schema. |
-| `CreateSchema<TValue>(JsonSchemaType type, string? format = null)` | Creates a schema with an explicit OpenAPI type and format. | When you want a primitive schema and prefer the typed helper overload. |
-| `CreateSchema<TValue>(JsonSchemaType type, string? format, TValue? defaultValue = null)` | Creates a schema with a typed default value. | When you want to document a primitive value and its default. |
-| `CreateSchema(IEnumerable<string> values, string? defaultValue = null)` | Creates a string schema with an enumeration of allowed values. | When the field is constrained to a fixed set of strings. |
-| `CreateSchema<TEnum>(TEnum? defaultValue = null)` | Creates a string schema from an enum type. | When you want the enum names to appear as OpenAPI values. |
+| `CreateStringSchema(string? defaultValue = null)` | Creates a reusable string schema with an optional default value. | When you want text-based contract metadata without rebuilding the same schema each time. |
+| `CreateSchema<TValue>(JsonSchemaType type, string? format = null)` | Creates a primitive schema with explicit OpenAPI type and format metadata. | When a filter needs to describe a primitive OpenAPI shape consistently. |
+| `CreateSchema<TValue>(JsonSchemaType type, string? format, TValue? defaultValue = null)` | Creates a primitive schema and includes the default value that clients should display or assume. | When you want to document both the value shape and its fallback. |
+| `CreateSchema(IEnumerable<string> values, string? defaultValue = null)` | Creates a string schema with an enumeration of externally defined allowed values. | When the field is constrained to a fixed set of strings that is not represented by a CLR enum. |
+| `CreateSchema<TEnum>(TEnum? defaultValue = null)` | Creates a string schema from an enum type so every declared value is documented. | When you want CLR enum names to appear as OpenAPI values. |
 
 ### Example
 
@@ -124,14 +129,6 @@ using TinyHelpers.AspNetCore.Swagger;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddSwaggerGen(options =>
-{
-    options.AddAcceptLanguageHeader();
-    options.AddDefaultProblemDetailsResponse();
-    options.AddTimeSpanTypeMapping("00:15:00");
-    options.AddOperationParameters();
-});
-
 builder.Services.AddSwaggerOperationParameters(parameters =>
 {
     parameters.Parameters.Add(new OpenApiParameter
@@ -141,6 +138,14 @@ builder.Services.AddSwaggerOperationParameters(parameters =>
         Required = false,
         Description = "Optional request correlation identifier"
     });
+});
+
+builder.Services.AddSwaggerGen(options =>
+{
+    options.AddAcceptLanguageHeader();
+    options.AddDefaultProblemDetailsResponse();
+    options.AddTimeSpanTypeMapping("00:15:00");
+    options.AddOperationParameters();
 });
 
 var app = builder.Build();

--- a/src/TinyHelpers.AspNetCore.Swashbuckle/SwaggerExtensions.cs
+++ b/src/TinyHelpers.AspNetCore.Swashbuckle/SwaggerExtensions.cs
@@ -49,8 +49,12 @@ public static class SwaggerExtensions
         }
 
         /// <summary>
-        /// Adds shared OpenAPI parameter definitions so they are automatically applied to every generated operation.
+        /// Registers the operation transformer that applies OpenAPI parameters added with <see cref="AddSwaggerOperationParameters(IServiceCollection, Action{OpenApiOperationOptions})" />.
         /// </summary>
+        /// <remarks>
+        /// Call <see cref="AddSwaggerOperationParameters(IServiceCollection, Action{OpenApiOperationOptions})" /> so the parameters are registered in dependency injection before this transformer runs.
+        /// </remarks>
+        /// <returns>The same <see cref="OpenApiOptions" /> for fluent configuration.</returns>
         /// <seealso cref="AddSwaggerOperationParameters(IServiceCollection, Action{OpenApiOperationOptions})"/>
         public void AddOperationParameters()
             => options.OperationFilter<OpenApiParametersOperationFilter>();

--- a/src/TinyHelpers.AspNetCore.Swashbuckle/SwaggerExtensions.cs
+++ b/src/TinyHelpers.AspNetCore.Swashbuckle/SwaggerExtensions.cs
@@ -49,23 +49,32 @@ public static class SwaggerExtensions
         }
 
         /// <summary>
-        /// Registers the operation transformer that applies OpenAPI parameters added with <see cref="AddSwaggerOperationParameters(IServiceCollection, Action{OpenApiOperationOptions})" />.
+        /// Adds the operation filter that copies registered shared parameters into each generated Swagger operation.
         /// </summary>
         /// <remarks>
-        /// Call <see cref="AddSwaggerOperationParameters(IServiceCollection, Action{OpenApiOperationOptions})" /> so the parameters are registered in dependency injection before this transformer runs.
+        /// Use this in Swagger configuration after registering parameters with
+        /// <see cref="AddSwaggerOperationParameters(IServiceCollection, Action{OpenApiOperationOptions})" />. Keeping
+        /// parameter definitions in dependency injection and applying them through a filter prevents duplicated route
+        /// metadata while preserving a complete contract for generated clients.
         /// </remarks>
-        /// <returns>The same <see cref="OpenApiOptions" /> for fluent configuration.</returns>
         /// <seealso cref="AddSwaggerOperationParameters(IServiceCollection, Action{OpenApiOperationOptions})"/>
         public void AddOperationParameters()
             => options.OperationFilter<OpenApiParametersOperationFilter>();
     }
 
     /// <summary>
-    /// Registers OpenAPI parameter definitions that can be automatically applied to every operation.
+    /// Registers shared Swagger operation parameters that can later be merged into generated operations.
     /// </summary>
     /// <param name="services">The service collection to extend.</param>
-    /// <param name="setupAction">The configuration callback used to populate shared parameters.</param>
+    /// <param name="setupAction">
+    /// A callback that adds reusable parameter definitions to an <see cref="OpenApiOperationOptions" /> instance.
+    /// </param>
     /// <returns>The same <see cref="IServiceCollection" /> instance so calls can be chained.</returns>
+    /// <remarks>
+    /// Call this during service registration when a parameter, such as a tenant, correlation, or feature header,
+    /// must appear consistently in the Swagger contract without being repeated on every endpoint. The registered
+    /// options are consumed by <see cref="AddOperationParameters(SwaggerGenOptions)" /> when the document is generated.
+    /// </remarks>
     /// <seealso cref="AddOperationParameters(SwaggerGenOptions)"/>
     public static IServiceCollection AddSwaggerOperationParameters(this IServiceCollection services, Action<OpenApiOperationOptions> setupAction)
     {

--- a/src/TinyHelpers.AspNetCore.Swashbuckle/TinyHelpers.AspNetCore.Swashbuckle.csproj
+++ b/src/TinyHelpers.AspNetCore.Swashbuckle/TinyHelpers.AspNetCore.Swashbuckle.csproj
@@ -23,7 +23,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <None Remove="inyHelpers.AspNetCore.Swashbuckle.xml" />
+        <None Remove="TinyHelpers.AspNetCore.Swashbuckle.xml" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/TinyHelpers.AspNetCore.Swashbuckle/TinyHelpers.AspNetCore.Swashbuckle.csproj
+++ b/src/TinyHelpers.AspNetCore.Swashbuckle/TinyHelpers.AspNetCore.Swashbuckle.csproj
@@ -6,6 +6,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>TinyHelpers.AspNetCore.Swagger</RootNamespace>
+        <DocumentationFile>TinyHelpers.AspNetCore.Swashbuckle.xml</DocumentationFile>
         <Authors>Marco Minerva</Authors>
         <Company>Marco Minerva</Company>
         <Product>Tiny Helpers for Swashbuckle ASP.NET Core</Product>
@@ -20,6 +21,10 @@
         <RepositoryBranch>master</RepositoryBranch>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
+
+    <ItemGroup>
+        <None Remove="inyHelpers.AspNetCore.Swashbuckle.xml" />
+    </ItemGroup>
 
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/TinyHelpers.AspNetCore/DataAnnotations/AllowedExtensionsAttribute.cs
+++ b/src/TinyHelpers.AspNetCore/DataAnnotations/AllowedExtensionsAttribute.cs
@@ -10,7 +10,8 @@ namespace TinyHelpers.AspNetCore.DataAnnotations;
 /// <param name="extensions">The allowed extensions, with or without the <c>*.</c> prefix.</param>
 /// <remarks>
 /// This attribute is useful when the extension is part of the contract, such as restricting uploads to image
-/// formats that downstream processing or security policies can safely handle.
+/// formats that downstream processing or security policies can safely handle. It complements content-type checks by
+/// documenting and enforcing the file-name contract exposed to users and API clients.
 /// </remarks>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
 public class AllowedExtensionsAttribute(params string[] extensions) : ValidationAttribute("Only files with the following extensions are supported: {0}")
@@ -33,7 +34,7 @@ public class AllowedExtensionsAttribute(params string[] extensions) : Validation
     }
 
     /// <summary>
-    /// Formats the validation error using the configured extension list.
+    /// Formats the validation error with the configured extension list so failed validation tells the caller which suffixes are accepted.
     /// </summary>
     /// <param name="name">The validated member name.</param>
     /// <returns>A localized error message that lists the allowed extensions.</returns>

--- a/src/TinyHelpers.AspNetCore/DataAnnotations/AllowedExtensionsAttribute.cs
+++ b/src/TinyHelpers.AspNetCore/DataAnnotations/AllowedExtensionsAttribute.cs
@@ -17,6 +17,7 @@ public class AllowedExtensionsAttribute(params string[] extensions) : Validation
 {
     private readonly IEnumerable<string> extensions = extensions.Select(e => e.Replace("*.", string.Empty));
 
+    /// <inheritdoc />
     protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
     {
         if (value is IFormFile file)

--- a/src/TinyHelpers.AspNetCore/DataAnnotations/ContentTypeAttribute.cs
+++ b/src/TinyHelpers.AspNetCore/DataAnnotations/ContentTypeAttribute.cs
@@ -10,8 +10,19 @@ namespace TinyHelpers.AspNetCore.DataAnnotations;
 /// </summary>
 public enum FileType
 {
+    /// <summary>
+    /// Represents image MIME types for upload scenarios where downstream processing expects visual media.
+    /// </summary>
     Image,
+
+    /// <summary>
+    /// Represents video MIME types for upload scenarios where downstream processing expects moving-picture media.
+    /// </summary>
     Video,
+
+    /// <summary>
+    /// Represents audio MIME types for upload scenarios where downstream processing expects sound media.
+    /// </summary>
     Audio
 }
 
@@ -59,6 +70,7 @@ public class ContentTypeAttribute : ValidationAttribute
         };
     }
 
+    /// <inheritdoc />
     protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
     {
         if (value is IFormFile formFile && !validContentTypes.Contains(formFile.ContentType, StringComparer.OrdinalIgnoreCase))

--- a/src/TinyHelpers.AspNetCore/DataAnnotations/ContentTypeAttribute.cs
+++ b/src/TinyHelpers.AspNetCore/DataAnnotations/ContentTypeAttribute.cs
@@ -31,7 +31,8 @@ public enum FileType
 /// </summary>
 /// <remarks>
 /// Use this attribute when the server depends on a known set of MIME types to avoid accepting files that cannot
-/// be rendered, transcoded, or safely processed later in the pipeline.
+/// be rendered, transcoded, or safely processed later in the pipeline. The accepted values become part of the
+/// validation contract, which helps clients discover failures before storage or media-processing work begins.
 /// </remarks>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
 public class ContentTypeAttribute : ValidationAttribute
@@ -45,7 +46,7 @@ public class ContentTypeAttribute : ValidationAttribute
     private const string DefaultErrorMessage = "The {0} field should have one of the following Content-Types: {1}";
 
     /// <summary>
-    /// Creates a new instance that accepts the specified MIME types.
+    /// Creates a new instance that accepts explicit MIME types when the built-in media categories are not precise enough.
     /// </summary>
     /// <param name="validContentTypes">The accepted content types, such as <c>image/png</c>.</param>
     public ContentTypeAttribute(params string[] validContentTypes)
@@ -55,7 +56,7 @@ public class ContentTypeAttribute : ValidationAttribute
     }
 
     /// <summary>
-    /// Creates a new instance using one of the built-in content type groups.
+    /// Creates a new instance using one of the built-in content type groups for common upload scenarios.
     /// </summary>
     /// <param name="fileType">The predefined file category to accept.</param>
     public ContentTypeAttribute(FileType fileType)
@@ -82,7 +83,7 @@ public class ContentTypeAttribute : ValidationAttribute
     }
 
     /// <summary>
-    /// Formats the validation error using the configured content types.
+    /// Formats the validation error with the configured content types.
     /// </summary>
     /// <param name="name">The validated member name.</param>
     /// <returns>A localized error message that lists the allowed content types.</returns>

--- a/src/TinyHelpers.AspNetCore/DataAnnotations/FileSizeAttribute.cs
+++ b/src/TinyHelpers.AspNetCore/DataAnnotations/FileSizeAttribute.cs
@@ -15,6 +15,7 @@ namespace TinyHelpers.AspNetCore.DataAnnotations;
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
 public class FileSizeAttribute(int maxFileSizeInBytes) : ValidationAttribute("The {0} field size cannot be bigger than {1} bytes")
 {
+    /// <inheritdoc />
     protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
     {
         if (value is IFormFile formFile && formFile.Length > maxFileSizeInBytes)

--- a/src/TinyHelpers.AspNetCore/DataAnnotations/FileSizeAttribute.cs
+++ b/src/TinyHelpers.AspNetCore/DataAnnotations/FileSizeAttribute.cs
@@ -10,7 +10,8 @@ namespace TinyHelpers.AspNetCore.DataAnnotations;
 /// <param name="maxFileSizeInBytes">The maximum accepted file size in bytes.</param>
 /// <remarks>
 /// This is intended for request boundaries where rejecting oversized payloads early is cheaper and clearer than
-/// allowing the file to progress into later validation or storage stages.
+/// allowing the file to progress into later validation or storage stages. The limit also documents the upload
+/// contract that clients should honor before sending content.
 /// </remarks>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
 public class FileSizeAttribute(int maxFileSizeInBytes) : ValidationAttribute("The {0} field size cannot be bigger than {1} bytes")
@@ -27,7 +28,7 @@ public class FileSizeAttribute(int maxFileSizeInBytes) : ValidationAttribute("Th
     }
 
     /// <summary>
-    /// Formats the validation error using the configured byte limit.
+    /// Formats the validation error with the configured byte limit so rejected uploads report the exact contract boundary.
     /// </summary>
     /// <param name="name">The validated member name.</param>
     /// <returns>A localized error message that includes the maximum file size.</returns>

--- a/src/TinyHelpers.AspNetCore/Extensions/RouteHandlerBuilderExtensions.cs
+++ b/src/TinyHelpers.AspNetCore/Extensions/RouteHandlerBuilderExtensions.cs
@@ -8,17 +8,25 @@ using Microsoft.OpenApi;
 namespace TinyHelpers.AspNetCore.Extensions;
 
 /// <summary>
-/// Adds minimal OpenAPI-focused helpers to <see cref="RouteHandlerBuilder" /> so endpoint metadata stays close to the route mapping code.
+/// Adds endpoint metadata helpers to <see cref="RouteHandlerBuilder" /> so route declarations and their OpenAPI behavior stay together.
 /// </summary>
+/// <remarks>
+/// Keeping response and header metadata next to the route mapping makes minimal APIs easier to review and helps the
+/// generated OpenAPI document remain synchronized with the endpoint behavior.
+/// </remarks>
 /// <seealso cref="RouteHandlerBuilder"/>
 public static class RouteHandlerBuilderExtensions
 {
     /// <summary>
-    /// Declares a set of problem responses on the endpoint.
+    /// Declares a set of <see cref="ProblemDetails" /> responses on the endpoint for expected failure status codes.
     /// </summary>
     /// <param name="builder">The route configuration being extended.</param>
     /// <param name="statusCodes">The HTTP status codes that should be described as <see cref="ProblemDetails" /> responses.</param>
     /// <returns>The same <see cref="RouteHandlerBuilder" /> so calls can be chained.</returns>
+    /// <remarks>
+    /// Use this helper when an endpoint can fail with several documented status codes and all of them share the same
+    /// problem-details payload shape.
+    /// </remarks>
     public static RouteHandlerBuilder ProducesDefaultProblem(this RouteHandlerBuilder builder, params int[] statusCodes)
     {
         foreach (var statusCode in statusCodes)

--- a/src/TinyHelpers.AspNetCore/Extensions/RouteHandlerBuilderExtensions.cs
+++ b/src/TinyHelpers.AspNetCore/Extensions/RouteHandlerBuilderExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 #if NET9_0_OR_GREATER
 using Microsoft.OpenApi;
 #endif

--- a/src/TinyHelpers.AspNetCore/Extensions/ServiceCollectionExtensions.cs
+++ b/src/TinyHelpers.AspNetCore/Extensions/ServiceCollectionExtensions.cs
@@ -13,8 +13,12 @@ using TinyHelpers.AspNetCore.ExceptionHandlers;
 namespace TinyHelpers.AspNetCore.Extensions;
 
 /// <summary>
-/// Registers common application services and configuration helpers that the library reuses across samples and packages.
+/// Registers common ASP.NET Core services and configuration helpers that reduce repeated setup in applications using the library.
 /// </summary>
+/// <remarks>
+/// These helpers intentionally keep the built-in dependency injection and options patterns visible while providing
+/// one-line registration for common localization, replacement, and problem-details conventions.
+/// </remarks>
 public static class ServiceCollectionExtensions
 {
     extension(IServiceCollection services)
@@ -36,21 +40,27 @@ public static class ServiceCollectionExtensions
         }
 
         /// <summary>
-        /// Registers request localization with a culture list.
+        /// Registers request localization with a culture list when the default provider order is sufficient.
         /// </summary>
         /// <param name="cultures">The supported culture names.</param>
         /// <returns>The same <see cref="IServiceCollection" /> so additional registrations can continue fluently.</returns>
-        /// <remarks>The first culture becomes the default.</remarks>
+        /// <remarks>
+        /// The first culture becomes the default so applications can define their fallback culture in the same order
+        /// they declare supported cultures.
+        /// </remarks>
         public IServiceCollection AddRequestLocalization(params string[] cultures)
             => services.AddRequestLocalization(cultures, null);
 
         /// <summary>
-        /// Registers request localization and allows the caller to adjust the culture-provider chain.
+        /// Registers request localization and allows the caller to adjust the culture-provider chain used during negotiation.
         /// </summary>
         /// <param name="cultures">The supported culture names.</param>
         /// <param name="providersConfiguration">A callback that can reorder or replace the request culture providers.</param>
         /// <returns>The same <see cref="IServiceCollection" /> so additional registrations can continue fluently.</returns>
-        /// <remarks>The first culture becomes the default.</remarks>
+        /// <remarks>
+        /// The first culture becomes the default. The provider callback exists for applications that need a specific
+        /// precedence, such as preferring route values over cookies or the <c>Accept-Language</c> header.
+        /// </remarks>
         public IServiceCollection AddRequestLocalization(IEnumerable<string> cultures, Action<IList<IRequestCultureProvider>>? providersConfiguration)
         {
             var supportedCultures = cultures.Select(c => new CultureInfo(c)).ToList();
@@ -67,12 +77,16 @@ public static class ServiceCollectionExtensions
         }
 
         /// <summary>
-        /// Replaces one registered service with another implementation while preserving the desired lifetime.
+        /// Replaces one registered service with another implementation when an application needs to override a library or framework default.
         /// </summary>
         /// <typeparam name="TService">The service contract to replace.</typeparam>
         /// <typeparam name="TImplementation">The implementation to register.</typeparam>
         /// <param name="lifetime">The lifetime that should be used for the replacement registration.</param>
         /// <returns>The same <see cref="IServiceCollection" /> so additional registrations can continue fluently.</returns>
+        /// <remarks>
+        /// This wraps the standard replacement pattern so callers can state the intended service contract and
+        /// implementation without manually creating a <see cref="ServiceDescriptor" />.
+        /// </remarks>
         public IServiceCollection Replace<TService, TImplementation>(ServiceLifetime lifetime = ServiceLifetime.Scoped)
             where TService : class
             where TImplementation : class, TService
@@ -86,6 +100,10 @@ public static class ServiceCollectionExtensions
         /// Registers a predictable <see cref="ProblemDetails" /> pipeline so the application emits consistent error payloads.
         /// </summary>
         /// <returns>The same <see cref="IServiceCollection" /> so additional registrations can continue fluently.</returns>
+        /// <remarks>
+        /// The customization fills common problem-details fields and a trace identifier, which gives clients and logs a
+        /// stable shape to correlate errors without requiring each application to repeat the same setup.
+        /// </remarks>
         public IServiceCollection AddDefaultProblemDetails()
         {
             services.AddProblemDetails(options =>
@@ -100,6 +118,10 @@ public static class ServiceCollectionExtensions
         /// Registers the library default exception handler so uncaught failures are shaped into problem details before they leave the pipeline.
         /// </summary>
         /// <returns>The same <see cref="IServiceCollection" /> so additional registrations can continue fluently.</returns>
+        /// <remarks>
+        /// Registering the handler with the problem-details service keeps unexpected failures consistent with explicit
+        /// validation and endpoint errors, which simplifies client error handling.
+        /// </remarks>
         public IServiceCollection AddDefaultExceptionHandler()
         {
             // Ensures that the ProblemDetails service is registered.

--- a/src/TinyHelpers.AspNetCore/Extensions/ServiceCollectionExtensions.cs
+++ b/src/TinyHelpers.AspNetCore/Extensions/ServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Localization;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -84,7 +85,6 @@ public static class ServiceCollectionExtensions
         /// <summary>
         /// Registers a predictable <see cref="ProblemDetails" /> pipeline so the application emits consistent error payloads.
         /// </summary>
-        /// <param name="services">The service collection being configured.</param>
         /// <returns>The same <see cref="IServiceCollection" /> so additional registrations can continue fluently.</returns>
         public IServiceCollection AddDefaultProblemDetails()
         {

--- a/src/TinyHelpers.AspNetCore/Middlewares/ApplicationBuilderExtensions.cs
+++ b/src/TinyHelpers.AspNetCore/Middlewares/ApplicationBuilderExtensions.cs
@@ -12,7 +12,6 @@ public static class ApplicationBuilderExtensions
         /// <summary>
         /// Enables request buffering so downstream middleware and services can re-read the body after an earlier component has inspected it.
         /// </summary>
-        /// <param name="app">The application pipeline being configured.</param>
         /// <returns>The <see cref="IApplicationBuilder" /> builder instance.</returns>
         public IApplicationBuilder UseRequestRewind()
             => app.UseMiddleware<EnableRequestRewindMiddleware>();

--- a/src/TinyHelpers.AspNetCore/Middlewares/ApplicationBuilderExtensions.cs
+++ b/src/TinyHelpers.AspNetCore/Middlewares/ApplicationBuilderExtensions.cs
@@ -3,7 +3,7 @@
 namespace TinyHelpers.AspNetCore.Middlewares;
 
 /// <summary>
-/// Provides middleware registration helpers.
+/// Provides middleware registration helpers for request-body behaviors that are otherwise easy to forget in pipeline setup.
 /// </summary>
 public static class ApplicationBuilderExtensions
 {

--- a/src/TinyHelpers.AspNetCore/OpenApi/OpenApiExtensions.cs
+++ b/src/TinyHelpers.AspNetCore/OpenApi/OpenApiExtensions.cs
@@ -1,6 +1,7 @@
 ﻿#if NET9_0_OR_GREATER
 
 using Microsoft.AspNetCore.OpenApi;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using TinyHelpers.AspNetCore.OpenApi.Transformers;
 
@@ -107,7 +108,6 @@ public static class OpenApiExtensions
         /// <summary>
         /// Configures schema reference IDs to include the namespace so types with the same name do not collide in large models.
         /// </summary>
-        /// <param name="options">The <see cref="OpenApiOptions"/> to configure.</param>
         /// <returns>The same <see cref="OpenApiOptions" /> instance for further customization.</returns>
         /// <remarks>
         /// OpenAPI defaults to the short type name, which is easy to read but can produce duplicate schema IDs when a

--- a/src/TinyHelpers.AspNetCore/OpenApi/OpenApiExtensions.cs
+++ b/src/TinyHelpers.AspNetCore/OpenApi/OpenApiExtensions.cs
@@ -57,8 +57,11 @@ public static class OpenApiExtensions
         }
 
         /// <summary>
-        /// Adds shared OpenAPI parameter definitions so they are automatically applied to every generated operation.
+        /// Registers the operation transformer that applies OpenAPI parameters added with <see cref="AddOpenApiOperationParameters(IServiceCollection, Action{OpenApiOperationOptions})" />.
         /// </summary>
+        /// <remarks>
+        /// Call <see cref="AddOpenApiOperationParameters(IServiceCollection, Action{OpenApiOperationOptions})" /> so the parameters are registered in dependency injection before this transformer runs.
+        /// </remarks>
         /// <returns>The same <see cref="OpenApiOptions" /> for fluent configuration.</returns>
         /// <seealso cref="AddOpenApiOperationParameters(IServiceCollection, Action{OpenApiOperationOptions})"/>
         public OpenApiOptions AddOperationParameters()

--- a/src/TinyHelpers.AspNetCore/OpenApi/OpenApiExtensions.cs
+++ b/src/TinyHelpers.AspNetCore/OpenApi/OpenApiExtensions.cs
@@ -8,17 +8,29 @@ using TinyHelpers.AspNetCore.OpenApi.Transformers;
 namespace TinyHelpers.AspNetCore.OpenApi;
 
 /// <summary>
-/// Adds OpenAPI configuration helpers that keep the generated contract aligned with the library's conventions.
+/// Adds opinionated <see cref="OpenApiOptions" /> and service-registration helpers used to keep generated OpenAPI
+/// documents aligned with the runtime behavior configured by this library.
 /// </summary>
+/// <remarks>
+/// These helpers centralize reusable OpenAPI conventions, such as shared operation parameters and default error
+/// responses, so applications do not need to repeat the same transformer setup for every document or endpoint.
+/// </remarks>
 public static class OpenApiExtensions
 {
     extension(IServiceCollection services)
     {
         /// <summary>
-        /// Registers OpenAPI parameter definitions that can be automatically applied to every operation.
+        /// Registers shared OpenAPI operation parameters that can later be merged into generated operations.
         /// </summary>
-        /// <param name="setupAction">A callback that fills the parameter options object.</param>
-        /// <returns>The same <see cref="IServiceCollection" /> for fluent registration.</returns>
+        /// <param name="setupAction">
+        /// A callback that adds reusable parameter definitions to an <see cref="OpenApiOperationOptions" /> instance.
+        /// </param>
+        /// <returns>The same <see cref="IServiceCollection" /> instance so registrations can continue fluently.</returns>
+        /// <remarks>
+        /// Call this during service registration when a parameter, such as a tenant, correlation, or feature header,
+        /// must appear consistently in the OpenAPI contract without being repeated on every endpoint. The registered
+        /// options are consumed by <see cref="AddOperationParameters(OpenApiOptions)" /> when the OpenAPI document is generated.
+        /// </remarks>
         /// <seealso cref="AddOperationParameters(OpenApiOptions)"/>
         public IServiceCollection AddOpenApiOperationParameters(Action<OpenApiOperationOptions> setupAction)
         {
@@ -58,12 +70,15 @@ public static class OpenApiExtensions
         }
 
         /// <summary>
-        /// Registers the operation transformer that applies OpenAPI parameters added with <see cref="AddOpenApiOperationParameters(IServiceCollection, Action{OpenApiOperationOptions})" />.
+        /// Adds the operation transformer that copies registered shared parameters into each generated OpenAPI operation.
         /// </summary>
         /// <remarks>
-        /// Call <see cref="AddOpenApiOperationParameters(IServiceCollection, Action{OpenApiOperationOptions})" /> so the parameters are registered in dependency injection before this transformer runs.
+        /// Use this in the OpenAPI document configuration after registering parameters with
+        /// <see cref="AddOpenApiOperationParameters(IServiceCollection, Action{OpenApiOperationOptions})" />. Keeping
+        /// parameter definitions in dependency injection and applying them through a transformer prevents duplicated
+        /// route metadata while preserving a complete contract for generated clients.
         /// </remarks>
-        /// <returns>The same <see cref="OpenApiOptions" /> for fluent configuration.</returns>
+        /// <returns>The same <see cref="OpenApiOptions" /> instance so OpenAPI configuration can continue fluently.</returns>
         /// <seealso cref="AddOpenApiOperationParameters(IServiceCollection, Action{OpenApiOperationOptions})"/>
         public OpenApiOptions AddOperationParameters()
             => options.AddOperationTransformer<OpenApiParametersOperationFilter>();

--- a/src/TinyHelpers.AspNetCore/OpenApi/OpenApiSchemaHelper.cs
+++ b/src/TinyHelpers.AspNetCore/OpenApi/OpenApiSchemaHelper.cs
@@ -15,7 +15,7 @@ public static class OpenApiSchemaHelper
     /// Creates a string schema with an optional default value.
     /// </summary>
     /// <param name="defaultValue">The optional default value.</param>
-    /// <returns>A schema configured for <see cref="JsonSchemaType.String" />.</returns>
+    /// <returns>A schema configured for the OpenAPI string type.</returns>
     public static OpenApiSchema CreateStringSchema(string? defaultValue = null)
     {
         var schema = new OpenApiSchema

--- a/src/TinyHelpers.AspNetCore/OpenApi/OpenApiSchemaHelper.cs
+++ b/src/TinyHelpers.AspNetCore/OpenApi/OpenApiSchemaHelper.cs
@@ -9,10 +9,14 @@ namespace TinyHelpers.AspNetCore.OpenApi;
 /// <summary>
 /// Creates reusable schema fragments so OpenAPI transformers can express the same contract details without duplicating schema setup.
 /// </summary>
+/// <remarks>
+/// These factory methods keep schema construction consistent across transformers that need to describe default values,
+/// formats, and enum choices for generated clients.
+/// </remarks>
 public static class OpenApiSchemaHelper
 {
     /// <summary>
-    /// Creates a string schema with an optional default value.
+    /// Creates a string schema with an optional default value for reusable text-based contract metadata.
     /// </summary>
     /// <param name="defaultValue">The optional default value.</param>
     /// <returns>A schema configured for the OpenAPI string type.</returns>
@@ -28,7 +32,7 @@ public static class OpenApiSchemaHelper
     }
 
     /// <summary>
-    /// Creates a schema with the specified type and format.
+    /// Creates a typed schema with an optional format when a transformer needs to describe a primitive OpenAPI shape.
     /// </summary>
     /// <typeparam name="TValue">The type associated with the schema.</typeparam>
     /// <param name="type">The OpenAPI type name.</param>
@@ -46,7 +50,7 @@ public static class OpenApiSchemaHelper
     }
 
     /// <summary>
-    /// Creates a typed schema with a default value.
+    /// Creates a typed schema with a default value so generated clients can display the same fallback used by the API contract.
     /// </summary>
     /// <typeparam name="TValue">The value type associated with the schema.</typeparam>
     /// <param name="type">The OpenAPI type name.</param>
@@ -66,7 +70,7 @@ public static class OpenApiSchemaHelper
     }
 
     /// <summary>
-    /// Creates a string enum schema from a known list of values.
+    /// Creates a string enum schema from a known list of values when the valid choices are defined outside a CLR enum.
     /// </summary>
     /// <param name="values">The allowed values to expose in the schema.</param>
     /// <param name="defaultValue">The optional default value.</param>
@@ -84,7 +88,7 @@ public static class OpenApiSchemaHelper
     }
 
     /// <summary>
-    /// Creates an enum schema from an <see cref="Enum"/> type.
+    /// Creates an enum schema from an <see cref="Enum"/> type so the generated document exposes every declared value.
     /// </summary>
     /// <typeparam name="TEnum">The enumeration type to describe.</typeparam>
     /// <param name="defaultValue">The optional default enum value.</param>
@@ -113,10 +117,14 @@ namespace TinyHelpers.AspNetCore.OpenApi;
 /// <summary>
 /// Creates reusable schema fragments so OpenAPI transformers can express the same contract details without duplicating schema setup.
 /// </summary>
+/// <remarks>
+/// These factory methods keep schema construction consistent across transformers that need to describe default values,
+/// formats, and enum choices for generated clients.
+/// </remarks>
 public static class OpenApiSchemaHelper
 {
     /// <summary>
-    /// Creates a string schema with an optional default value.
+    /// Creates a string schema with an optional default value for reusable text-based contract metadata.
     /// </summary>
     /// <param name="defaultValue">The optional default value.</param>
     /// <returns>A schema configured for <see cref="JsonSchemaType.String" />.</returns>
@@ -132,7 +140,7 @@ public static class OpenApiSchemaHelper
     }
 
     /// <summary>
-    /// Creates a schema with the specified type and format.
+    /// Creates a typed schema with an optional format when a transformer needs to describe a primitive OpenAPI shape.
     /// </summary>
     /// <typeparam name="TValue">The type associated with the schema.</typeparam>
     /// <param name="type">The OpenAPI type value.</param>
@@ -150,7 +158,7 @@ public static class OpenApiSchemaHelper
     }
 
     /// <summary>
-    /// Creates a typed schema with a default value.
+    /// Creates a typed schema with a default value so generated clients can display the same fallback used by the API contract.
     /// </summary>
     /// <typeparam name="TValue">The type associated with the schema.</typeparam>
     /// <param name="type">The OpenAPI type value.</param>
@@ -170,7 +178,7 @@ public static class OpenApiSchemaHelper
     }
 
     /// <summary>
-    /// Creates a string enum schema from a known list of values.
+    /// Creates a string enum schema from a known list of values when the valid choices are defined outside a CLR enum.
     /// </summary>
     /// <param name="values">The allowed values to expose in the schema.</param>
     /// <param name="defaultValue">The optional default value.</param>
@@ -188,7 +196,7 @@ public static class OpenApiSchemaHelper
     }
 
     /// <summary>
-    /// Creates an enum schema from an <see cref="Enum"/> type.
+    /// Creates an enum schema from an <see cref="Enum"/> type so the generated document exposes every declared value.
     /// </summary>
     /// <typeparam name="TEnum">The enumeration type to describe.</typeparam>
     /// <param name="defaultValue">The optional default enum value.</param>

--- a/src/TinyHelpers.AspNetCore/OpenApi/Transformers/CamelCaseQueryParametersOperationTransformer.cs
+++ b/src/TinyHelpers.AspNetCore/OpenApi/Transformers/CamelCaseQueryParametersOperationTransformer.cs
@@ -6,6 +6,9 @@ using Microsoft.OpenApi.Models;
 
 namespace TinyHelpers.AspNetCore.OpenApi.Transformers;
 
+/// <summary>
+/// Normalizes generated query-parameter names to camel case so the OpenAPI document matches common ASP.NET Core JSON naming conventions.
+/// </summary>
 public class CamelCaseQueryParametersOperationTransformer : IOpenApiOperationTransformer
 {
     /// <summary>
@@ -38,6 +41,9 @@ using Microsoft.OpenApi;
 
 namespace TinyHelpers.AspNetCore.OpenApi.Transformers;
 
+/// <summary>
+/// Normalizes generated query-parameter names to camel case so the OpenAPI document matches common ASP.NET Core JSON naming conventions.
+/// </summary>
 public class CamelCaseQueryParametersOperationTransformer : IOpenApiOperationTransformer
 {
     /// <summary>

--- a/src/TinyHelpers.AspNetCore/OpenApi/Transformers/DefaultResponseOperationTransformer.cs
+++ b/src/TinyHelpers.AspNetCore/OpenApi/Transformers/DefaultResponseOperationTransformer.cs
@@ -51,10 +51,19 @@ using Microsoft.OpenApi;
 
 namespace TinyHelpers.AspNetCore.OpenApi;
 
+/// <summary>
+/// Adds a conventional default problem-details response to operations so API clients can discover a consistent error contract.
+/// </summary>
 public class DefaultResponseOperationTransformer : IOpenApiOperationTransformer
 {
+    /// <summary>
+    /// Gets or sets the response key used for the fallback error response when a specific status code is not documented.
+    /// </summary>
     public string DefaultResponseCode { get; set; } = "default";
 
+    /// <summary>
+    /// Gets or sets the description applied to the fallback error response so generated documents have meaningful failure metadata.
+    /// </summary>
     public string DefaultDescription { get; set; } = "Error";
 
     /// <summary>

--- a/src/TinyHelpers.AspNetCore/OpenApi/Transformers/OpenApiOperationOptions.cs
+++ b/src/TinyHelpers.AspNetCore/OpenApi/Transformers/OpenApiOperationOptions.cs
@@ -9,7 +9,8 @@ namespace TinyHelpers.AspNetCore.OpenApi;
 /// </summary>
 /// <remarks>
 /// The library uses this options object to register shared parameter definitions once and copy them into the
-/// generated OpenAPI document wherever they are needed, which keeps endpoint setup centralized and avoids drift.
+/// generated OpenAPI document wherever they are needed. This keeps endpoint setup centralized and avoids drift between
+/// route metadata and the generated client contract.
 /// </remarks>
 public class OpenApiOperationOptions
 {
@@ -18,11 +19,11 @@ public class OpenApiOperationOptions
     }
 
     /// <summary>
-    /// Gets the parameter definitions that should be merged into matching OpenAPI operations.
+    /// Gets the parameter definitions that should be merged into generated OpenAPI operations.
     /// </summary>
     /// <remarks>
-    /// Parameters are intentionally stored here rather than declared inline on each route so callers can reuse the
-    /// same metadata across multiple endpoints and keep the generated contract consistent.
+    /// Parameters are intentionally stored here rather than declared inline on each route so callers can reuse metadata
+    /// for cross-cutting inputs such as headers or query values while keeping the generated contract consistent.
     /// </remarks>
     public IList<OpenApiParameter> Parameters { get; } = [];
 }
@@ -38,7 +39,8 @@ namespace TinyHelpers.AspNetCore.OpenApi;
 /// </summary>
 /// <remarks>
 /// The library uses this options object to register shared parameter definitions once and copy them into the
-/// generated OpenAPI document wherever they are needed, which keeps endpoint setup centralized and avoids drift.
+/// generated OpenAPI document wherever they are needed. This keeps endpoint setup centralized and avoids drift between
+/// route metadata and the generated client contract.
 /// </remarks>
 public class OpenApiOperationOptions
 {
@@ -47,11 +49,11 @@ public class OpenApiOperationOptions
     }
 
     /// <summary>
-    /// Gets the parameter definitions that should be merged into matching OpenAPI operations.
+    /// Gets the parameter definitions that should be merged into generated OpenAPI operations.
     /// </summary>
     /// <remarks>
-    /// Parameters are intentionally stored here rather than declared inline on each route so callers can reuse the
-    /// same metadata across multiple endpoints and keep the generated contract consistent.
+    /// Parameters are intentionally stored here rather than declared inline on each route so callers can reuse metadata
+    /// for cross-cutting inputs such as headers or query values while keeping the generated contract consistent.
     /// </remarks>
     public IList<OpenApiParameter> Parameters { get; } = [];
 }

--- a/src/TinyHelpers.AspNetCore/OpenApi/Transformers/OpenApiOperationOptions.cs
+++ b/src/TinyHelpers.AspNetCore/OpenApi/Transformers/OpenApiOperationOptions.cs
@@ -33,12 +33,26 @@ using Microsoft.OpenApi;
 
 namespace TinyHelpers.AspNetCore.OpenApi;
 
+/// <summary>
+/// Collects reusable OpenAPI operation metadata that should be applied consistently across multiple endpoints.
+/// </summary>
+/// <remarks>
+/// The library uses this options object to register shared parameter definitions once and copy them into the
+/// generated OpenAPI document wherever they are needed, which keeps endpoint setup centralized and avoids drift.
+/// </remarks>
 public class OpenApiOperationOptions
 {
     internal OpenApiOperationOptions()
     {
     }
 
+    /// <summary>
+    /// Gets the parameter definitions that should be merged into matching OpenAPI operations.
+    /// </summary>
+    /// <remarks>
+    /// Parameters are intentionally stored here rather than declared inline on each route so callers can reuse the
+    /// same metadata across multiple endpoints and keep the generated contract consistent.
+    /// </remarks>
     public IList<OpenApiParameter> Parameters { get; } = [];
 }
 

--- a/src/TinyHelpers.AspNetCore/OpenApi/Transformers/TimeExampleSchemaTransformer.cs
+++ b/src/TinyHelpers.AspNetCore/OpenApi/Transformers/TimeExampleSchemaTransformer.cs
@@ -6,6 +6,9 @@ using Microsoft.OpenApi.Models;
 
 namespace TinyHelpers.AspNetCore.OpenApi.Transformers;
 
+/// <summary>
+/// Adds representative examples to time-based schemas so generated OpenAPI documents communicate the expected wire format.
+/// </summary>
 public class TimeExampleSchemaTransformer : IOpenApiSchemaTransformer
 {
     /// <summary>
@@ -35,6 +38,9 @@ using Microsoft.OpenApi;
 
 namespace TinyHelpers.AspNetCore.OpenApi.Transformers;
 
+/// <summary>
+/// Adds representative examples to time-based schemas so generated OpenAPI documents communicate the expected wire format.
+/// </summary>
 public class TimeExampleSchemaTransformer : IOpenApiSchemaTransformer
 {
     /// <summary>

--- a/src/TinyHelpers.AspNetCore/README.md
+++ b/src/TinyHelpers.AspNetCore/README.md
@@ -23,9 +23,9 @@ The package targets:
 - .NET 9
 - .NET 10
 
-OpenAPI features are available when the consuming project targets .NET 9 or .NET 10. Some extensions are also framework-specific:
+OpenAPI features are available when the consuming project targets .NET 9 or .NET 10. Some extensions are framework-specific:
 
-- `EnableEnumSupport()` is available only on .NET 9+
+- `EnableEnumSupport()` is available only on .NET 9
 - `UseStrictNumericSchemas()` is available only on .NET 10+
 - `WithResponseDescription()` and `WithLocationHeader()` are available only on .NET 10+
 
@@ -110,11 +110,11 @@ var hasName = principal.HasClaim(ClaimTypes.Name);
 | --- | --- | --- |
 | `ConfigureAndGet<T>(configuration, sectionName)` | Binds a section and also registers the options in the container, returning the created instance. | When you want to configure and read the same options during startup. |
 | `Replace<TService, TImplementation>(lifetime)` | Replaces a registered service with another implementation. | When you want to swap a service without rewriting the whole registration. |
-| `AddDefaultProblemDetails()` | Registers `ProblemDetails` with a consistent and centralized configuration. | When you want uniform RFC 7807 responses across the app. |
-| `AddDefaultExceptionHandler()` | Registers the library's default `IExceptionHandler` and ensures `ProblemDetails` is available too. | When you want unhandled exceptions to become a standard payload. |
-| `UseDefaults(ProblemDetailsContext context)` | Applies the library's default values to a `ProblemDetailsContext`. | When you customize `CustomizeProblemDetails` but still want the same base behavior. |
-| `AddRequestLocalization(params string[] cultures)` | Registers localization using only the list of supported cultures. The first culture becomes the default. | When you do not need to configure providers manually. |
-| `AddRequestLocalization(IEnumerable<string> cultures, Action<IList<IRequestCultureProvider>>? providersConfiguration)` | Registers localization and lets you customize the culture-provider chain. The first culture becomes the default. | When you want to change the provider order or composition. |
+| `AddDefaultProblemDetails()` | Registers `ProblemDetails` with defaults for common fields and a trace identifier. | When you want uniform RFC 7807 responses that are easy to correlate in clients and logs. |
+| `AddDefaultExceptionHandler()` | Registers the library's default `IExceptionHandler` and ensures `ProblemDetails` is available too. | When you want unhandled exceptions to use the same payload shape as explicit errors. |
+| `UseDefaults(ProblemDetailsContext context)` | Applies the library's default values to a `ProblemDetailsContext`. | When you customize `CustomizeProblemDetails` but still want the same base error contract. |
+| `AddRequestLocalization(params string[] cultures)` | Registers localization using only the list of supported cultures. The first culture becomes the default. | When the default provider order is enough. |
+| `AddRequestLocalization(IEnumerable<string> cultures, Action<IList<IRequestCultureProvider>>? providersConfiguration)` | Registers localization and lets you customize the culture-provider chain. The first culture becomes the default. | When you want a specific precedence, such as route values before cookies or the `Accept-Language` header. |
 
 ### Example
 
@@ -138,7 +138,7 @@ builder.Services.AddDefaultExceptionHandler();
 
 | Method | What it does | When to use it |
 | --- | --- | --- |
-| `UseRequestRewind()` | Enables request-body buffering so the body can be read more than once. | When a middleware or filter must inspect the body without consuming it permanently. |
+| `UseRequestRewind()` | Enables request-body buffering so the body can be read more than once. | When middleware or filters must inspect the body for validation, auditing, or request-signature checks without consuming it permanently. |
 
 ### `EnableRequestRewindMiddleware`
 
@@ -159,14 +159,14 @@ if (navManager.TryGetQueryString<int>("page", out var page))
 
 ### `AllowedExtensionsAttribute`
 
-Validates that an `IFormFile` uses one of the allowed file extensions.
+Validates that an `IFormFile` uses one of the allowed file extensions. Use it when the file-name suffix is part of the upload contract and downstream processing or policy checks require known formats.
 
 - Constructor: `AllowedExtensionsAttribute(params string[] extensions)`
 - `FormatErrorMessage(string name)`: generates the error message with the allowed extensions
 
 ### `ContentTypeAttribute`
 
-Validates the `Content-Type` of an `IFormFile`.
+Validates the `Content-Type` of an `IFormFile`. Use it when the server accepts only MIME types that can be rendered, transcoded, stored, or otherwise processed safely.
 
 - `ContentTypeAttribute(params string[] validContentTypes)`: uses an explicit MIME type list
 - `ContentTypeAttribute(FileType fileType)`: uses a predefined group
@@ -174,7 +174,7 @@ Validates the `Content-Type` of an `IFormFile`.
 
 ### `FileType`
 
-Supporting enum for `ContentTypeAttribute`:
+Supporting enum for the built-in `ContentTypeAttribute` MIME type groups:
 
 - `Image`
 - `Video`
@@ -182,14 +182,14 @@ Supporting enum for `ContentTypeAttribute`:
 
 ### `FileSizeAttribute`
 
-Validates that an `IFormFile` does not exceed a maximum size.
+Validates that an `IFormFile` does not exceed a maximum size. Use it to reject oversized uploads at the request boundary before later validation, storage, or media-processing work starts.
 
 - Constructor: `FileSizeAttribute(int maxFileSizeInBytes)`
 - `FormatErrorMessage(string name)`: generates the error message with the limit in bytes
 
 ### `RoleAuthorizeAttribute`
 
-Automatically builds the `Roles` list of `AuthorizeAttribute` from one or more roles.
+Automatically builds the `Roles` list of `AuthorizeAttribute` from one or more role values, keeping role-based authorization declarations readable without manually composing a comma-delimited string.
 
 - Constructor: `RoleAuthorizeAttribute(params string[] roles)`
 
@@ -219,11 +219,11 @@ public IActionResult SecretArea()
 
 | Method | What it does | Availability |
 | --- | --- | --- |
-| `ProducesDefaultProblem(params int[] statusCodes)` | Adds `ProblemDetails` responses to the route metadata for the specified status codes. | .NET 8+ |
-| `WithResponseDescription(int statusCode, string description)` | Updates the description of an existing OpenAPI response. | .NET 10+ |
-| `WithLocationHeader(string description, int statusCode)` | Adds a `Location` header to the specified creation response. | .NET 10+ |
+| `ProducesDefaultProblem(params int[] statusCodes)` | Adds `ProblemDetails` responses to the route metadata for expected failure status codes. | .NET 8+ |
+| `WithResponseDescription(int statusCode, string description)` | Updates the description of an existing OpenAPI response when the generated text is too generic. | .NET 10+ |
+| `WithLocationHeader(string description, int statusCode)` | Adds a required `Location` header to the specified creation response. | .NET 10+ |
 
-These helpers keep Minimal API configuration close to the route instead of scattering OpenAPI metadata in separate places.
+These helpers keep Minimal API behavior and OpenAPI metadata close to the route mapping. This makes endpoint declarations easier to review and helps the generated document stay synchronized with runtime behavior.
 
 ### Example
 
@@ -242,16 +242,16 @@ app.MapPost("/orders", () => Results.Created("/orders/1", new { Id = 1 }))
 
 ## OpenAPI
 
-The OpenAPI extensions are available when the consuming project uses the package on .NET 9 or .NET 10.
+The OpenAPI extensions are available when the consuming project uses the package on .NET 9 or .NET 10. They centralize reusable OpenAPI conventions so shared parameters, error responses, schema IDs, and schema transformations do not need to be repeated for every endpoint or document.
 
 ### `OpenApiExtensions`
 
 | Method | What it does | Notes |
 | --- | --- | --- |
-| `AddOpenApiOperationParameters(setupAction)` | Registers reusable OpenAPI parameters inside `OpenApiOperationOptions.Parameters`. | Lets you declare common parameters once. |
+| `AddOpenApiOperationParameters(setupAction)` | Registers reusable OpenAPI operation parameters inside `OpenApiOperationOptions.Parameters`. | Declare cross-cutting headers or query values once during service registration. |
 | `AddAcceptLanguageHeader()` | Adds the `Accept-Language` header to documented operations. | Useful when the app uses request localization. |
 | `AddDefaultProblemDetailsResponse()` | Adds a default error response based on `ProblemDetails`. | In .NET 9 it also adds the document transformer. |
-| `AddOperationParameters()` | Adds the parameters configured through `OpenApiOperationOptions`. | The bridge between the options bag and the generated document. |
+| `AddOperationParameters()` | Adds the operation transformer that copies parameters registered with `AddOpenApiOperationParameters()` into generated operations. | Use it in OpenAPI configuration so the generated contract includes those shared inputs. |
 | `RemoveServerList()` | Removes the server list from the OpenAPI document. | Useful when you want a more portable document across environments. |
 | `WriteNumberAsString()` | Aligns the schema with numbers serialized as strings. | Useful when runtime JSON uses `JsonNumberHandling.WriteAsString`. |
 | `DescribeAllParametersInCamelCase()` | Converts query parameter names to camel case in the document. | Keeps documentation consistent with JSON naming. |
@@ -262,7 +262,7 @@ The OpenAPI extensions are available when the consuming project uses the package
 
 ### `OpenApiSchemaHelper`
 
-This utility creates ready-to-use schema fragments that can be reused in transformers or other OpenAPI customizations.
+This utility creates ready-to-use schema fragments that can be reused in transformers or other OpenAPI customizations. It keeps default values, formats, and enum choices consistent across generated documents.
 
 #### .NET 9
 
@@ -282,11 +282,11 @@ This utility creates ready-to-use schema fragments that can be reused in transfo
 
 ### What they do in practice
 
-- `CreateStringSchema()` creates a simple string schema, optionally with a default.
-- `CreateSchema(..., format)` creates a schema with explicit type and format.
-- `CreateSchema(..., defaultValue)` also adds a default to the contract.
-- `CreateSchema(IEnumerable<string> values, ...)` turns a list of values into a string-based OpenAPI enum.
-- `CreateSchema<TEnum>(...)` builds an enum schema directly from a CLR enum.
+- `CreateStringSchema()` creates a reusable string schema, optionally with a default value.
+- `CreateSchema(..., format)` creates a primitive schema with explicit type and format metadata.
+- `CreateSchema(..., defaultValue)` also adds the default value that clients should display or assume.
+- `CreateSchema(IEnumerable<string> values, ...)` turns externally defined choices into a string-based OpenAPI enum.
+- `CreateSchema<TEnum>(...)` builds an enum schema directly from a CLR enum so every declared value is documented.
 
 ### Example
 
@@ -312,6 +312,8 @@ builder.Services.AddOpenApi(options =>
 
 ### Example `AddOpenApiOperationParameters()`
 
+Register shared parameters during service registration, then enable `AddOperationParameters()` in OpenAPI configuration. This keeps cross-cutting inputs centralized while still exposing them in the generated client contract.
+
 ```csharp
 builder.Services.AddOpenApiOperationParameters(parameters =>
 {
@@ -322,6 +324,11 @@ builder.Services.AddOpenApiOperationParameters(parameters =>
         Required = false,
         Description = "Identifier used to correlate requests"
     });
+});
+
+builder.Services.AddOpenApi(options =>
+{
+    options.AddOperationParameters();
 });
 ```
 

--- a/src/TinyHelpers.AspNetCore/TinyHelpers.AspNetCore.csproj
+++ b/src/TinyHelpers.AspNetCore/TinyHelpers.AspNetCore.csproj
@@ -5,6 +5,7 @@
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <DocumentationFile>TinyHelpers.AspNetCore.xml</DocumentationFile>
         <Authors>Marco Minerva</Authors>
         <Company>Marco Minerva</Company>
         <Product>Tiny Helpers for ASP.NET Core</Product>
@@ -19,6 +20,10 @@
         <RepositoryBranch>master</RepositoryBranch>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
+
+    <ItemGroup>
+        <None Remove="TinyHelpers.AspNetCore.xml" />
+    </ItemGroup>
 
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/TinyHelpers/Extensions/CollectionExtensions.cs
+++ b/src/TinyHelpers/Extensions/CollectionExtensions.cs
@@ -5,8 +5,12 @@ using System.Linq.Expressions;
 namespace TinyHelpers.Extensions;
 
 /// <summary>
-/// Contains extension methods for collections.
+/// Provides collection and sequence helpers that keep common null-safety, indexing, asynchronous projection, and conditional filtering patterns reusable.
 /// </summary>
+/// <remarks>
+/// These extensions are intended for application code that repeatedly composes LINQ queries or optional collections and
+/// should avoid scattering small guard clauses and loop helpers across the codebase.
+/// </remarks>
 public static class CollectionExtensions
 {
 #if NETSTANDARD2_0
@@ -45,7 +49,7 @@ public static class CollectionExtensions
 #endif
 
     /// <summary>
-    /// Returns the elements of an <see cref="IEnumerable{TSource}"/>, or an empty singleton collection if the sequence is <see langword="null"/>.
+    /// Returns the source sequence or an empty sequence when the source is <see langword="null" /> so callers can enumerate safely.
     /// </summary>
     /// <typeparam name="TSource">The type of the data in the <code>source</code>.</typeparam>
     /// <param name="source">The sequence to return a default value for if it is <see langword="null"/>.</param>
@@ -54,7 +58,7 @@ public static class CollectionExtensions
         => source ?? [];
 
     /// <summary>
-    /// Returns the elements of an <see cref="IQueryable{TSource}"/>, or an empty singleton collection if the sequence is <see langword="null"/>.
+    /// Returns the source query or an empty query when the source is <see langword="null" /> so query composition can continue safely.
     /// </summary>
     /// <typeparam name="TSource">The type of the data in the <code>source</code>.</typeparam>
     /// <param name="source">The sequence to return a default value for if it is <see langword="null"/>.</param>
@@ -63,12 +67,12 @@ public static class CollectionExtensions
         => source ?? Array.Empty<TSource>().AsQueryable();
 
     /// <summary>
-    /// Performs the specified action on each element of the <see cref="IEnumerable{TSource}"/>.
+    /// Performs an action for each item and returns the original sequence so side-effect steps can remain in a fluent pipeline.
     /// </summary>
     /// <typeparam name="TSource">The type of the data in the <code>source</code>.</typeparam>
     /// <param name="source">The sequence on whose elements apply the <code>action</code> to.</param>
     /// <param name="action">The <see cref="Action{TSource}"/> delegate to perform on each element of the collection.</param>
-    /// <returns>An <see cref="IEnumerable{TSource}"/> whose elements are the result of invoking the <code>action</code> on each element of <code>source</code>.</returns>
+    /// <returns>The original <paramref name="source" /> sequence after <paramref name="action" /> has been invoked for each item.</returns>
     public static IEnumerable<TSource> ForEach<TSource>(this IEnumerable<TSource> source, Action<TSource> action)
     {
         foreach (var item in source)
@@ -80,13 +84,13 @@ public static class CollectionExtensions
     }
 
     /// <summary>
-    /// Asynchronously performs the specified action on each element of the <see cref="IEnumerable{TSource}"/>.
+    /// Performs an asynchronous action for each item and returns the original sequence after every action completes.
     /// </summary>
     /// <typeparam name="TSource">The type of the data in the <code>source</code>.</typeparam>
     /// <param name="source">The sequence on whose elements apply the <code>action</code> to.</param>
     /// <param name="action">An asynchronous delegate that is invoked once per element in the data source.</param>
     /// <param name="cancellationToken">A token that can be used to request cancellation of the asynchronous operation.</param>
-    /// <returns>An <see cref="IEnumerable{TSource}" /> whose elements are the result of invoking the <code>action</code> on each element of <code>source</code>.</returns>
+    /// <returns>The original <paramref name="source" /> sequence after every asynchronous action has completed.</returns>
     public static async Task<IEnumerable<TSource>> ForEachAsync<TSource>(this IEnumerable<TSource> source, Func<TSource, Task> action, CancellationToken cancellationToken = default)
     {
         foreach (var item in source)
@@ -99,12 +103,12 @@ public static class CollectionExtensions
     }
 
     /// <summary>
-    /// Asynchronously projects each element of a sequence into a new form.
+    /// Projects each item with an asynchronous selector while preserving the source order in the materialized result.
     /// </summary>
     /// <typeparam name="TSource">The type of the elements of <code>source</code>.</typeparam>
     /// <typeparam name="TResult">The type of the value returned by <code>selector</code>.</typeparam>
     /// <param name="source">A sequence of values to invoke a transform function on.</param>
-    /// <param name="selector">A transform function to apply to each source element; the second parameter of the function represents the index of the source element.</param>
+    /// <param name="selector">A transform function to apply to each source element.</param>
     /// <param name="cancellationToken">A token that can be used to request cancellation of the asynchronous operation.</param>
     /// <returns>An <see cref="IEnumerable{TResult}" /> whose elements are the result of invoking the transform function on each element of <code>source</code>.</returns>
     /// <exception cref="ArgumentNullException"><code>source</code> is <code>null</code></exception>    
@@ -250,7 +254,7 @@ public static class CollectionExtensions
         => (predicate is null ? source?.LongCount() : source?.LongCount(predicate)) ?? 0;
 
     /// <summary>
-    /// Filters a sequence of values based on a condition.
+    /// Applies a filter only when <paramref name="condition" /> is <see langword="true" /> so optional filters can remain in a fluent pipeline.
     /// </summary>
     /// <typeparam name="TSource">The type of the elements.</typeparam>
     /// <param name="source">The <see cref="IEnumerable{TSource}"/> to check.</param>    
@@ -261,7 +265,7 @@ public static class CollectionExtensions
         => condition ? source.Where(predicate) : source;
 
     /// <summary>
-    /// Filters a sequence of values based on a condition.
+    /// Applies a queryable filter only when <paramref name="condition" /> is <see langword="true" /> so optional query predicates remain composable.
     /// </summary>
     /// <typeparam name="TSource">The type of the elements.</typeparam>
     /// <param name="source">The <see cref="IQueryable{TSource}"/> to check.</param>    

--- a/src/TinyHelpers/Extensions/DateTimeOffsetExtensions.cs
+++ b/src/TinyHelpers/Extensions/DateTimeOffsetExtensions.cs
@@ -11,8 +11,8 @@ public static class DateTimeOffsetExtensions
     /// Constructs a <see cref="DateOnly"/> object that is set to the date part of the specified <see cref="DateTimeOffset"/>.
     /// </summary>
     /// <param name="dateTimeOffset">The <see cref="DateTimeOffset"/> object to extract the date part from.</param>
-    /// <param name="zone">The optional <see cref="TimeZoneInfo"/> to apply to the resulting <see cref="DateTimeOffset"/> value.</param>
-    /// <returns>A <see cref="DateOnly"/> object representing date of the day specified in the <paramref name="dateTimeOffset"/> object.</returns>
+    /// <param name="zone">The optional <see cref="TimeZoneInfo" /> to apply to the resulting <see cref="DateOnly"/> value; UTC is used when no zone is specified.</param>
+    /// <returns>A <see cref="DateOnly" /> value for the date in the selected time zone.</returns>
     /// <seealso cref="DateTimeOffset"/>
     /// <seealso cref="DateOnly"/>
     /// <seealso cref="TimeZoneInfo"/>
@@ -26,15 +26,15 @@ public static class DateTimeOffsetExtensions
     /// Constructs a <see cref="TimeOnly"/> object from a <see cref="DateTimeOffset"/> representing the time of the day in this <see cref="DateTimeOffset"/> object.
     /// </summary>
     /// <param name="dateTimeOffset">The <see cref="DateTimeOffset"/> object to extract the time of the day from.</param>
-    /// <param name="zone">The optional <see cref="TimeZoneInfo"/> to apply to the resulting <see cref="DateTimeOffset"/> value.</param>
-    /// <returns>A <see cref="TimeOnly"/> object representing time of the day specified in the <paramref name="dateTimeOffset"/> object.</returns>
+    /// <param name="zone">The optional <see cref="TimeZoneInfo" /> to apply to the resulting <see cref="TimeOnly"/> value; UTC is used when no zone is specified.</param>
+    /// <returns>A <see cref="TimeOnly" /> value for the time in the selected time zone.</returns>
     /// <seealso cref="DateTimeOffset"/>
     /// <seealso cref="TimeOnly"/>
     /// <seealso cref="TimeZoneInfo"/>
     public static TimeOnly ToTimeOnly(this DateTimeOffset dateTimeOffset, TimeZoneInfo? zone = null)
     {
         var inTargetZone = TimeZoneInfo.ConvertTime(dateTimeOffset, zone ?? TimeZoneInfo.Utc);
-        return TimeOnly.FromDateTime(dateTimeOffset.DateTime);
+        return TimeOnly.FromDateTime(inTargetZone.DateTime);
     }
 #endif
 }

--- a/src/TinyHelpers/Extensions/GuidExtensions.cs
+++ b/src/TinyHelpers/Extensions/GuidExtensions.cs
@@ -4,7 +4,7 @@ using TinyHelpers.Enums;
 namespace TinyHelpers.Extensions;
 
 /// <summary>
-/// Contains extensions methods for the <see cref="Guid"/> type.
+/// Provides <see cref="Guid" /> helpers for treating <see cref="Guid.Empty" /> as a missing identifier and creating fallback values consistently.
 /// </summary>
 public static class GuidExtensions
 {
@@ -63,15 +63,15 @@ public static class GuidExtensions
         => !input.IsEmpty();
 
     /// <summary>
-    /// Gets the actual value of this <see cref="Guid"/> instance, if it is different from <c>Guid.Empty</c>; otherwise, creates a new <see cref="Guid"/> using <see cref="Guid.NewGuid()"/>.
+    /// Returns the current identifier when it is not <see cref="Guid.Empty" />; otherwise, creates a new random identifier.
     /// </summary>
     /// <param name="input">The <see cref="Guid"/> to test.</param>
-    /// <returns>The actual value of this <see cref="Guid"/> instance, if it is different from <c>Guid.Empty</c>; otherwise, a new <see cref="Guid"/> created with <see cref="Guid.NewGuid()"/>.</returns>
+    /// <returns>The current identifier when it is not empty; otherwise, a new value created with <see cref="Guid.NewGuid()" />.</returns>
     public static Guid GetValueOrCreateNew(this Guid input)
         => input.IsEmpty() ? Guid.NewGuid() : input;
 
     /// <summary>
-    /// Gets the actual value of this <see cref="Guid"/> instance, if it is different from <c>Guid.Empty</c>; otherwise, returns the specified default value.
+    /// Returns the current identifier when it is not <see cref="Guid.Empty" />; otherwise, returns a caller-provided fallback value.
     /// </summary>
     /// <param name="input">The <see cref="Guid"/> to test.</param>
     /// <param name="defaultValue">The default <see cref="Guid"/> to return if the input is <c>Guid.Empty</c>.</param>
@@ -80,7 +80,7 @@ public static class GuidExtensions
         => input.IsEmpty() ? defaultValue : input;
 
     /// <summary>
-    /// Gets the actual value of this <see cref="Guid"/> instance, if it is different from <see langword="null"/> and <c>Guid.Empty</c>; otherwise, creates a new <see cref="Guid"/> using <see cref="Guid.NewGuid()"/>.
+    /// Returns the current identifier when it is not <see langword="null" /> or <see cref="Guid.Empty" />; otherwise, creates a new random identifier.
     /// </summary>
     /// <param name="input">The <see cref="Guid"/> to test.</param>
     /// <returns>The actual value of this <see cref="Guid"/> instance, if it is different from <see langword="null"/> and <c>Guid.Empty</c>; otherwise, a new <see cref="Guid"/> created with <see cref="Guid.NewGuid()"/>.</returns>
@@ -89,11 +89,11 @@ public static class GuidExtensions
 
 #if NET9_0_OR_GREATER
     /// <summary>
-    /// Gets the actual value of this <see cref="Guid"/> instance, if it is different from <c>Guid.Empty</c>; otherwise, creates a new <see cref="Guid"/> using <see cref="Guid.NewGuid()"/>.
+    /// Returns the current identifier when it is not <see cref="Guid.Empty" />; otherwise, creates a new identifier using the requested GUID version.
     /// </summary>
     /// <param name="input">The <see cref="Guid"/> to test.</param>
     /// <param name="guidVersion">The version of the <see cref="Guid"/> to create if the input is <c>Guid.Empty</c>.</param>
-    /// <returns>The actual value of this <see cref="Guid"/> instance, if it is different from <c>Guid.Empty</c>; otherwise, a new <see cref="Guid"/>.</returns>
+    /// <returns>The current identifier when it is not empty; otherwise, a new identifier using <paramref name="guidVersion" />.</returns>
     public static Guid GetValueOrCreateNew(this Guid input, GuidVersion guidVersion)
         => input.IsEmpty() ? guidVersion switch
         {
@@ -102,11 +102,11 @@ public static class GuidExtensions
         } : input;
 
     /// <summary>
-    /// Gets the actual value of this <see cref="Guid"/> instance, if it is different from <see langword="null"/> and <c>Guid.Empty</c>; otherwise, creates a new <see cref="Guid"/>.
+    /// Returns the current identifier when it is not <see langword="null" /> or <see cref="Guid.Empty" />; otherwise, creates a new identifier using the requested GUID version.
     /// </summary>
     /// <param name="input">The <see cref="Guid"/> to test.</param>
     /// <param name="guidVersion">The version of the <see cref="Guid"/> to create if the input is <see langword="null"/> or <c>Guid.Empty</c>.</param>
-    /// <returns>The actual value of this <see cref="Guid"/> instance, if it is different from <see langword="null"/> and <c>Guid.Empty</c>; otherwise, a new <see cref="Guid"/>.</returns>
+    /// <returns>The current identifier when it has a value; otherwise, a new identifier using <paramref name="guidVersion" />.</returns>
     public static Guid GetValueOrCreateNew(this Guid? input, GuidVersion guidVersion)
         => input.IsEmpty() ? guidVersion switch
         {

--- a/src/TinyHelpers/Http/AuthenticatedParameterizedHttpClientHandler.cs
+++ b/src/TinyHelpers/Http/AuthenticatedParameterizedHttpClientHandler.cs
@@ -4,12 +4,16 @@ using System.Net.Http.Headers;
 namespace TinyHelpers.Http;
 
 /// <summary>
-/// Represents a handler to authenticate HTTP requests using Bearer token.
+/// Adds an authorization token to outgoing HTTP requests and can refresh the token once after an unauthorized response.
 /// </summary>
+/// <remarks>
+/// Use this handler when token acquisition depends on the current <see cref="HttpRequestMessage" />, such as per-tenant
+/// or per-resource tokens, and the client needs a lightweight retry path for expired credentials.
+/// </remarks>
 public class AuthenticatedParameterizedHttpClientHandler : DelegatingHandler
 {
     /// <summary>
-    /// Scheme for Bearer authorization.
+    /// The default authorization scheme used when the request does not already specify one.
     /// </summary>
     public const string BearerAuthorizationScheme = "Bearer";
 
@@ -19,11 +23,11 @@ public class AuthenticatedParameterizedHttpClientHandler : DelegatingHandler
     private readonly string authorizationScheme;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="AuthenticatedParameterizedHttpClientHandler"/> class.
+    /// Initializes a new handler that can add request-specific authorization tokens and optionally refresh them.
     /// </summary>
-    /// <param name="getToken">Delegate function to get access token for authentication.</param>
-    /// <param name="refreshToken">Optional delegate function to refresh access token.</param>
-    /// <param name="checkAuthorizationHeader">Indicates if there should be an Authorization header.</param>
+    /// <param name="getToken">Delegate used to get the access token for the current request.</param>
+    /// <param name="refreshToken">Optional delegate used to refresh the access token after a <see cref="HttpStatusCode.Unauthorized" /> response.</param>
+    /// <param name="checkAuthorizationHeader">Indicates whether a token should only be added when the request already has an authorization header.</param>
     /// <param name="authorizationScheme">The authorization scheme used for the HTTP request.</param>
     /// <exception cref="ArgumentNullException"><paramref name="getToken"/> is <see langword="null"/>.</exception>
     public AuthenticatedParameterizedHttpClientHandler(Func<HttpRequestMessage, Task<string>> getToken, Func<HttpRequestMessage, Task>? refreshToken = null, bool checkAuthorizationHeader = true, string authorizationScheme = BearerAuthorizationScheme)
@@ -35,10 +39,10 @@ public class AuthenticatedParameterizedHttpClientHandler : DelegatingHandler
     }
 
     /// <summary>
-    /// Constructor for AuthenticatedParameterizedHttpClientHandler.
+    /// Initializes a new handler with a custom inner handler and request-specific token provider.
     /// </summary>
-    /// <param name="getToken">Delegate function to get access token for authentication.</param>
-    /// <param name="innerHandler">Inner handler to send request to.</param>
+    /// <param name="getToken">Delegate used to get the access token for the current request.</param>
+    /// <param name="innerHandler">The next handler in the HTTP pipeline.</param>
     /// <param name="authorizationScheme">The authorization scheme used for the HTTP request.</param>
     /// <exception cref="ArgumentNullException"><paramref name="getToken"/> is <see langword="null"/>.</exception>
     public AuthenticatedParameterizedHttpClientHandler(Func<HttpRequestMessage, Task<string>> getToken, HttpMessageHandler innerHandler, string authorizationScheme = BearerAuthorizationScheme)
@@ -47,11 +51,11 @@ public class AuthenticatedParameterizedHttpClientHandler : DelegatingHandler
     }
 
     /// <summary>
-    /// Constructor for AuthenticatedParameterizedHttpClientHandler.
+    /// Initializes a new handler with a custom inner handler, request-specific token provider, and token refresh callback.
     /// </summary>
-    /// <param name="getToken">Delegate function to get access token for authentication.</param>
-    /// <param name="refreshToken">Delegate function to refresh access token.</param>
-    /// <param name="innerHandler">Inner handler to send request to.</param>
+    /// <param name="getToken">Delegate used to get the access token for the current request.</param>
+    /// <param name="refreshToken">Delegate used to refresh the access token after a <see cref="HttpStatusCode.Unauthorized" /> response.</param>
+    /// <param name="innerHandler">The next handler in the HTTP pipeline.</param>
     /// <param name="authorizationScheme">The authorization scheme used for the HTTP request.</param>
     /// <exception cref="ArgumentNullException"><paramref name="getToken"/> is <see langword="null"/>.</exception>
     public AuthenticatedParameterizedHttpClientHandler(Func<HttpRequestMessage, Task<string>> getToken, Func<HttpRequestMessage, Task>? refreshToken, HttpMessageHandler innerHandler, string authorizationScheme = BearerAuthorizationScheme)
@@ -60,12 +64,12 @@ public class AuthenticatedParameterizedHttpClientHandler : DelegatingHandler
     }
 
     /// <summary>
-    /// Constructor for AuthenticatedParameterizedHttpClientHandler.
+    /// Initializes a new handler with full control over token refresh, authorization-header behavior, and the inner handler.
     /// </summary>
-    /// <param name="getToken">Delegate function to get access token for authentication.</param>
-    /// <param name="refreshToken">Delegate function to refresh access token.</param>
-    /// <param name="checkAuthorizationHeader">Indicates if there should be an Authorization header.</param>
-    /// <param name="innerHandler">Inner handler for HTTP message request to be sent to.</param>
+    /// <param name="getToken">Delegate used to get the access token for the current request.</param>
+    /// <param name="refreshToken">Delegate used to refresh the access token after a <see cref="HttpStatusCode.Unauthorized" /> response.</param>
+    /// <param name="checkAuthorizationHeader">Indicates whether a token should only be added when the request already has an authorization header.</param>
+    /// <param name="innerHandler">The next handler in the HTTP pipeline.</param>
     /// <param name="authorizationScheme">The authorization scheme used for the HTTP request.</param>
     /// <exception cref="ArgumentNullException"><paramref name="getToken"/> is <see langword="null"/>.</exception>
     public AuthenticatedParameterizedHttpClientHandler(Func<HttpRequestMessage, Task<string>> getToken, Func<HttpRequestMessage, Task>? refreshToken, bool checkAuthorizationHeader, HttpMessageHandler innerHandler, string authorizationScheme = BearerAuthorizationScheme)
@@ -78,7 +82,7 @@ public class AuthenticatedParameterizedHttpClientHandler : DelegatingHandler
     }
 
     /// <summary>
-    /// Calls the function to automatically add the Bearer token and then sends an HTTP request to the inner handler to send to the server as an asynchronous operation. If the response is 401 (Unauthorized), it will try to refresh the token using the handler specified in the <see cref="AuthenticatedParameterizedHttpClientHandler"/> constructor and try again.
+    /// Adds the configured authorization token before sending the request and retries once after refreshing the token when the response is unauthorized.
     /// </summary>
     /// <param name="request">The HTTP request message to send to the server.</param>
     /// <param name="cancellationToken">A cancellation token to cancel operation.</param>

--- a/src/TinyHelpers/Http/HeaderInjectorHttpClientHandler.cs
+++ b/src/TinyHelpers/Http/HeaderInjectorHttpClientHandler.cs
@@ -1,8 +1,12 @@
 ﻿namespace TinyHelpers.Http;
 
 /// <summary>
-/// Represents a handler for injecting headers in an HTTP request message.
+/// Adds request-specific headers to outgoing HTTP requests before they continue through the client pipeline.
 /// </summary>
+/// <remarks>
+/// Use this handler to centralize cross-cutting headers such as correlation identifiers, tenant identifiers, or custom
+/// API metadata without repeating header setup at every call site.
+/// </remarks>
 public class HeaderInjectorHttpClientHandler : DelegatingHandler
 {
     private readonly Func<HttpRequestMessage, Task<Dictionary<string, string>>> getHeaders;
@@ -30,7 +34,7 @@ public class HeaderInjectorHttpClientHandler : DelegatingHandler
     }
 
     /// <summary>
-    /// Calls the function to get headers and then sends an HTTP request to the inner handler to send to the server as an asynchronous operation.
+    /// Resolves headers for the current request, adds them without strict validation, and sends the request to the next handler.
     /// </summary>
     /// <param name="request">The HTTP request message to send to the server.</param>
     /// <param name="cancellationToken">A cancellation token to cancel operation.</param>

--- a/src/TinyHelpers/Http/QueryStringInjectorHttpClientHandler.cs
+++ b/src/TinyHelpers/Http/QueryStringInjectorHttpClientHandler.cs
@@ -3,8 +3,12 @@
 namespace TinyHelpers.Http;
 
 /// <summary>
-/// Represents a handler for adding query string parameters to an HTTP request message.
+/// Adds request-specific query string parameters to outgoing HTTP requests before they continue through the client pipeline.
 /// </summary>
+/// <remarks>
+/// Use this handler when query values depend on the current request context and URL composition should be centralized,
+/// such as pagination, tenant selection, or feature flags.
+/// </remarks>
 public class QueryStringInjectorHttpClientHandler : DelegatingHandler
 {
     private readonly Func<HttpRequestMessage, Task<Dictionary<string, string>>> getQueryString;
@@ -32,7 +36,7 @@ public class QueryStringInjectorHttpClientHandler : DelegatingHandler
     }
 
     /// <summary>
-    /// Calls the function to get query string parameters and then sends an HTTP request to the inner handler to send to the server as an asynchronous operation.
+    /// Merges query string parameters for the current request into the URI and sends the request to the next handler.
     /// </summary>
     /// <param name="request">The HTTP request message to send to the server.</param>
     /// <param name="cancellationToken">A cancellation token to cancel operation.</param>

--- a/src/TinyHelpers/Json/Serialization/ShortDateConverter.cs
+++ b/src/TinyHelpers/Json/Serialization/ShortDateConverter.cs
@@ -5,11 +5,12 @@ using System.Text.Json.Serialization;
 namespace TinyHelpers.Json.Serialization;
 
 /// <summary>
-/// Converts a <see cref="DateTime"/> value to or from JSON, keeping only the date part.
+/// Converts a <see cref="DateTime" /> value to or from JSON while preserving only the date portion of the contract.
 /// </summary>
 /// <seealso cref="DateTime"/>
 /// <remarks>
-/// Initializes a new instance of the <see cref="ShortDateConverter"/> class with a specified serialization format.
+/// Use this converter when time-of-day information is not part of the JSON contract and clients should exchange a
+/// stable date-only representation.
 /// </remarks>
 /// <param name="serializationFormat">The serialization format to use. The default is yyyy-MM-dd.</param>
 public class ShortDateConverter(string? serializationFormat) : JsonConverter<DateTime>

--- a/src/TinyHelpers/Json/Serialization/StringTrimmingConverter.cs
+++ b/src/TinyHelpers/Json/Serialization/StringTrimmingConverter.cs
@@ -4,8 +4,12 @@ using System.Text.Json.Serialization;
 namespace TinyHelpers.Json.Serialization;
 
 /// <summary>
-/// A converter to trim the whitespace from JSON strings during serialization and deserialization.
+/// Trims leading and trailing whitespace from JSON string values during serialization and deserialization.
 /// </summary>
+/// <remarks>
+/// Use this converter when the JSON boundary should normalize user-entered text before it reaches the domain model or
+/// before values are written back to clients.
+/// </remarks>
 public class StringTrimmingConverter : JsonConverter<string>
 {
     /// <inheritdoc/>

--- a/src/TinyHelpers/Json/Serialization/TimeSpanTicksConverter.cs
+++ b/src/TinyHelpers/Json/Serialization/TimeSpanTicksConverter.cs
@@ -4,7 +4,7 @@ using System.Text.Json.Serialization;
 namespace TinyHelpers.Json.Serialization;
 
 /// <summary>
-/// A converter for serializing and deserializing <see cref="TimeSpan"/> as ticks.
+/// Converts <see cref="TimeSpan" /> values to JSON ticks so durations can be round-tripped without format ambiguity.
 /// </summary>
 /// <seealso cref="TimeSpan"/>
 public class TimeSpanTicksConverter : JsonConverter<TimeSpan>

--- a/src/TinyHelpers/Json/Serialization/UtcDateTimeConverter.cs
+++ b/src/TinyHelpers/Json/Serialization/UtcDateTimeConverter.cs
@@ -4,11 +4,12 @@ using System.Text.Json.Serialization;
 namespace TinyHelpers.Json.Serialization;
 
 /// <summary>
-/// A converter for serializing and deserializing <see cref="DateTime"/> values converting them to UTC, if needed.
+/// Converts <see cref="DateTime" /> values to UTC during JSON serialization and deserialization.
 /// </summary>
 /// <seealso cref="DateTime"/>
 /// <remarks>
-/// Initializes a new instance of the <see cref="UtcDateTimeConverter"/> class with a specified serialization format.
+/// Use this converter when a JSON contract should normalize date-time values to a UTC wire format instead of preserving
+/// local offsets or unspecified kinds.
 /// </remarks>
 /// <param name="serializationFormat">The serialization format to use. The default is <c>yyyy-MM-ddTHH:mm:ss.fffffffZ</c>.</param>
 /// <seealso cref="UtcDateTimeConverter"/>

--- a/src/TinyHelpers/Threading/AsyncLock.cs
+++ b/src/TinyHelpers/Threading/AsyncLock.cs
@@ -1,8 +1,12 @@
 ﻿namespace TinyHelpers.Threading;
 
 /// <summary>
-/// Provides a lock that can be used asynchronously.
+/// Provides an asynchronous mutual-exclusion primitive for protecting shared state without blocking worker threads.
 /// </summary>
+/// <remarks>
+/// Await <see cref="LockAsync(CancellationToken)" /> and dispose the returned instance when the critical section ends.
+/// Timed overloads return <see cref="LockResult" /> so callers can handle contention without exceptions.
+/// </remarks>
 public sealed class AsyncLock : IDisposable
 #if !NETSTANDARD2_0
     , IAsyncDisposable

--- a/src/TinyHelpers/Threading/LockResult.cs
+++ b/src/TinyHelpers/Threading/LockResult.cs
@@ -1,17 +1,21 @@
 ﻿namespace TinyHelpers.Threading;
 
 /// <summary>
-/// Represents the result of an asynchronous lock operation.
+/// Represents the outcome of a timed <see cref="Threading.AsyncLock" /> acquisition attempt.
 /// </summary>
+/// <remarks>
+/// Timed lock attempts need to distinguish between successful acquisition and timeout without throwing. This value
+/// carries both the ownership flag and the lock instance that must be disposed when ownership is granted.
+/// </remarks>
 public readonly struct LockResult
 {
     /// <summary>
-    /// Gets the <seealso cref="Threading.AsyncLock"/> object if successfully acquired.
+    /// Gets the <see cref="Threading.AsyncLock" /> instance to dispose when the lock was acquired.
     /// </summary>
     public AsyncLock? AsyncLock { get; }
 
     /// <summary>
-    /// Gets a boolean indicating if the lock was acquired or not.
+    /// Gets a value indicating whether the lock was acquired before the timeout elapsed.
     /// </summary>
     public bool IsOwned { get; }
 


### PR DESCRIPTION
This pull request focuses on improving the documentation, clarity, and usability of both the main `TinyHelpers` library and the `TinyHelpers.AspNetCore.Swashbuckle` package. The changes make the libraries' contracts, extension methods, and Swagger integration points more explicit and easier to understand for consumers. The most important changes are grouped below.

### Documentation and Usability Improvements

* Expanded and clarified method summaries, usage scenarios, and intent throughout the `README.md` files for both packages, making it clearer when and why to use each helper or extension method. This includes more explicit descriptions of method contracts, scenarios, and improved table explanations for collection, date/time, GUID, HTTP, and JSON helpers. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L9-R9) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L51-R65) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L152-R154) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L198-R199) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L218-R219) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L235-R236) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L254-R255) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L276-R289) [[9]](diffhunk://#diff-9739992f2db71a8e138dfcf0c75a483306ff832fadee2b0b717e5934040fcb33L11-R11) [[10]](diffhunk://#diff-9739992f2db71a8e138dfcf0c75a483306ff832fadee2b0b717e5934040fcb33L46-L66) [[11]](diffhunk://#diff-9739992f2db71a8e138dfcf0c75a483306ff832fadee2b0b717e5934040fcb33R69-R97) [[12]](diffhunk://#diff-9739992f2db71a8e138dfcf0c75a483306ff832fadee2b0b717e5934040fcb33L127-L134) [[13]](diffhunk://#diff-9739992f2db71a8e138dfcf0c75a483306ff832fadee2b0b717e5934040fcb33R143-R150)
* Added new guidance and rationale for when to use certain helpers, such as when to centralize query string or header injection, or how to use the shared Swagger parameter registration mechanism. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L218-R219) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L235-R236) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L254-R255) [[4]](diffhunk://#diff-9739992f2db71a8e138dfcf0c75a483306ff832fadee2b0b717e5934040fcb33L46-L66) [[5]](diffhunk://#diff-9739992f2db71a8e138dfcf0c75a483306ff832fadee2b0b717e5934040fcb33R69-R97)

### Swagger and OpenAPI Integration Enhancements

* Improved the XML documentation and comments for the `OpenApiOperationOptions` class and related Swagger extension methods, making it clear that shared parameters should be registered once and are automatically injected into generated Swagger operations. This prevents duplicated endpoint metadata and keeps the OpenAPI contract consistent. [[1]](diffhunk://#diff-e03eeb23a2c62f20c3fc041c1dd679f26da1cab12da83663b6f70a231d6a92beL6-R11) [[2]](diffhunk://#diff-e03eeb23a2c62f20c3fc041c1dd679f26da1cab12da83663b6f70a231d6a92beL23-R28) [[3]](diffhunk://#diff-c32b33b6dc8d9c4a6c189af92891c26a914f9a54c53e6181c53db7b9f88643c7L52-R77)
* Updated the Swagger extension methods to better explain their roles, especially for registering and applying shared operation parameters, and clarified the difference between registering parameters and enabling their injection into the Swagger document. [[1]](diffhunk://#diff-c32b33b6dc8d9c4a6c189af92891c26a914f9a54c53e6181c53db7b9f88643c7L52-R77) [[2]](diffhunk://#diff-9739992f2db71a8e138dfcf0c75a483306ff832fadee2b0b717e5934040fcb33L46-L66)
* Improved the example Swagger configuration in the documentation to demonstrate best practices for registering and applying shared parameters and filters. [[1]](diffhunk://#diff-9739992f2db71a8e138dfcf0c75a483306ff832fadee2b0b717e5934040fcb33R69-R97) [[2]](diffhunk://#diff-9739992f2db71a8e138dfcf0c75a483306ff832fadee2b0b717e5934040fcb33L127-L134) [[3]](diffhunk://#diff-9739992f2db71a8e138dfcf0c75a483306ff832fadee2b0b717e5934040fcb33R143-R150)

### Project and Build Improvements

* Added a `<DocumentationFile>` entry to the Swashbuckle package project file to generate XML documentation for consumers, and ensured the XML file is not accidentally included as content. [[1]](diffhunk://#diff-a6e6aa412733d48734c96722e07da8e12c5a8a24e206863f48dfac5aa85a53a7R9) [[2]](diffhunk://#diff-a6e6aa412733d48734c96722e07da8e12c5a8a24e206863f48dfac5aa85a53a7R25-R28)

These changes collectively make the libraries easier to use, reduce ambiguity for consumers, and improve the maintainability and discoverability of shared helpers and Swagger integration points.