### PR TITLE
Enhance ConfigureAndGet with optional configure callback

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -124,6 +124,7 @@ csharp_style_prefer_null_check_over_type_check = true:suggestion
 
 # Modifier preferences
 csharp_prefer_static_local_function = true:suggestion
+csharp_prefer_static_anonymous_function = true:suggestion
 csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:silent
 
 # Code-block preferences
@@ -139,9 +140,11 @@ csharp_prefer_system_threading_lock = true:suggestion
 csharp_prefer_simple_default_expression = true:suggestion
 csharp_style_deconstructed_variable_declaration = false:suggestion
 csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_prefer_implicitly_typed_lambda_expression = true:suggestion
 csharp_style_pattern_local_over_anonymous_function = true:suggestion
 csharp_style_prefer_index_operator = true:suggestion
 csharp_style_prefer_range_operator = true:suggestion
+csharp_style_prefer_unbound_generic_type_in_nameof = true:suggestion
 csharp_style_throw_expression = true:suggestion
 csharp_style_unused_value_assignment_preference = discard_variable:none
 csharp_style_unused_value_expression_statement_preference = discard_variable:none

--- a/src/TinyHelpers.AspNetCore/Extensions/ServiceCollectionExtensions.cs
+++ b/src/TinyHelpers.AspNetCore/Extensions/ServiceCollectionExtensions.cs
@@ -29,11 +29,18 @@ public static class ServiceCollectionExtensions
         /// <typeparam name="T">The options type to bind.</typeparam>
         /// <param name="configuration">The configuration root that contains the section.</param>
         /// <param name="sectionName">The section path to bind.</param>
+        /// <param name="configure">An optional callback to further configure the options instance.</param>
         /// <returns>The bound settings instance, or <see langword="null" /> if the section could not be materialized.</returns>
-        public T? ConfigureAndGet<T>(IConfiguration configuration, string sectionName) where T : class
+        public T? ConfigureAndGet<T>(IConfiguration configuration, string sectionName, Action<T>? configure = null) where T : class
         {
             var section = configuration.GetSection(sectionName);
             var settings = section.Get<T>();
+
+            if (settings is not null)
+            {
+                configure?.Invoke(settings);
+            }
+
             services.Configure<T>(section);
 
             return settings;


### PR DESCRIPTION
Updated ConfigureAndGet to accept an optional Action<T> configure parameter, enabling callers to further customize the options instance after binding. The callback is invoked if the settings instance is not null. XML documentation was revised to describe the new parameter and its usage.